### PR TITLE
fix(PM-2540): removed isAIReviewer from challenge schema

### DIFF
--- a/prisma/challenge.schema.prisma
+++ b/prisma/challenge.schema.prisma
@@ -619,7 +619,7 @@ model DefaultChallengeReviewer {
   typeId              String
   trackId             String
   // Reviewer configuration (mirrors ChallengeReviewer)
-  scorecardId         String
+  scorecardId         String?
   isMemberReview      Boolean
   memberReviewerCount Int?
   phaseName           String
@@ -627,7 +627,7 @@ model DefaultChallengeReviewer {
   baseCoefficient           Float?
   incrementalCoefficient    Float?
   opportunityType     ReviewOpportunityTypeEnum?
-  isAIReviewer        Boolean
+  aiWorkflowId        String?
   // Default for whether to open a public review opportunity for this reviewer when a challenge is created
   shouldOpenOpportunity Boolean @default(true)
 


### PR DESCRIPTION
## What's in this PR?

- We have removed isAIReviewer column from DefaultChallengeReviewer table in challenge schema.
- This PR is to remove it here and update scorecardId as nullable
