### PR TITLE
PM-3926 AI screening phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ workflows:
             only:
               - develop
               - reviews
+              - PM-3926_ai-screening-phase
             
     # Production builds are exectuted only on tagged commits to the
     # master branch.

--- a/src/autopilot/constants/review.constants.ts
+++ b/src/autopilot/constants/review.constants.ts
@@ -1,4 +1,5 @@
 export const ITERATIVE_REVIEW_PHASE_NAME = 'Iterative Review';
+export const AI_SCREENING_PHASE_NAME = 'AI Screening';
 export const POST_MORTEM_PHASE_NAME = 'Post-Mortem';
 export const POST_MORTEM_PHASE_ALTERNATE_NAME = 'Post-mortem';
 export const POST_MORTEM_PHASE_NAMES = new Set<string>([

--- a/src/autopilot/interfaces/autopilot.interface.ts
+++ b/src/autopilot/interfaces/autopilot.interface.ts
@@ -133,6 +133,16 @@ export interface AppealRespondedPayload {
   finalScore: number;
 }
 
+export interface AiWorkflowCompletedPayload {
+  challengeId: string;
+  submissionId: string;
+  aiWorkflowRunId: string;
+  aiWorkflowId: string;
+  status: string;
+  score: number;
+  completedAt: string;
+}
+
 export interface First2FinishSubmissionPayload {
   challengeId: string;
   submissionId: string;

--- a/src/autopilot/services/autopilot.service.ts
+++ b/src/autopilot/services/autopilot.service.ts
@@ -619,7 +619,6 @@ export class AutopilotService {
         state: 'END',
         operator: AutopilotOperator.SYSTEM,
         projectStatus: challenge.status,
-        skipReviewCompletionCheck: true,
       });
     } catch (error) {
       const err = error as Error;

--- a/src/autopilot/services/autopilot.service.ts
+++ b/src/autopilot/services/autopilot.service.ts
@@ -16,6 +16,7 @@ import {
   AppealRespondedPayload,
   First2FinishSubmissionPayload,
   TopgearSubmissionPayload,
+  AiWorkflowCompletedPayload,
 } from '../interfaces/autopilot.interface';
 import { ChallengeApiService } from '../../challenge/challenge-api.service';
 import {
@@ -530,6 +531,101 @@ export class AutopilotService {
     } else {
       this.logger.warn(
         `No follow-up approval reviews created for challenge ${challenge.id}, phase ${nextPhase.id}; a pending review may already exist.`,
+      );
+    }
+  }
+
+  async handleAiWorkflowCompleted(
+    payload: AiWorkflowCompletedPayload,
+  ): Promise<void> {
+    const { challengeId } = payload;
+
+    if (!challengeId) {
+      this.logger.warn(
+        `AI workflow completion event missing challengeId; ignoring`,
+      );
+      return;
+    }
+
+    try {
+      const challenge =
+        await this.challengeApiService.getChallengeById(challengeId);
+
+      if (!challenge || !challenge.phases) {
+        this.logger.warn(
+          `Challenge ${challengeId} not found or has no phases; ignoring AI workflow completion`,
+        );
+        return;
+      }
+
+      // Import AI_SCREENING_PHASE_NAME from constants if needed
+      const aiScreeningPhase = challenge.phases.find(
+        (p) => p.name === 'AI Screening',
+      );
+
+      if (!aiScreeningPhase) {
+        this.logger.debug(
+          `No AI Screening phase found for challenge ${challengeId}; ignoring AI workflow completion`,
+        );
+        return;
+      }
+
+      if (!aiScreeningPhase.isOpen) {
+        this.logger.debug(
+          `AI Screening phase ${aiScreeningPhase.id} already closed for challenge ${challengeId}; ignoring AI workflow completion event`,
+        );
+        return;
+      }
+
+      // Get all AI workflow IDs configured for this challenge
+      const aiWorkflowIds = Array.from(
+        new Set(
+          (challenge.reviewers ?? [])
+            .map((reviewer) => reviewer.aiWorkflowId)
+            .filter((workflowId): workflowId is string => Boolean(workflowId)),
+        ),
+      );
+
+      if (aiWorkflowIds.length === 0) {
+        this.logger.debug(
+          `No AI workflows configured for challenge ${challengeId}; ignoring completion event`,
+        );
+        return;
+      }
+
+      // Check if there are any remaining in-progress AI workflows
+      const inProgressAiWorkflows =
+        await this.reviewService.getInProgressAiWorkflowRunCount(
+          challengeId,
+          aiWorkflowIds,
+        );
+
+      if (inProgressAiWorkflows > 0) {
+        this.logger.debug(
+          `AI Screening phase ${aiScreeningPhase.id} for challenge ${challengeId} still has ${inProgressAiWorkflows} in-progress AI workflow(s). Not closing phase.`,
+        );
+        return;
+      }
+
+      this.logger.log(
+        `All AI workflows completed for phase ${aiScreeningPhase.id} on challenge ${challengeId}. Closing AI Screening phase early.`,
+      );
+
+      await this.schedulerService.advancePhase({
+        projectId: challenge.projectId,
+        challengeId: challenge.id,
+        phaseId: aiScreeningPhase.id,
+        phaseTypeName: aiScreeningPhase.name,
+        state: 'END',
+        operator: AutopilotOperator.SYSTEM,
+        projectStatus: challenge.status,
+        skipReviewCompletionCheck: true,
+      });
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        `Failed to handle AI workflow completion for challenge ${challengeId}: ${err.message}`,
+        err.stack,
       );
     }
   }

--- a/src/autopilot/services/autopilot.service.ts
+++ b/src/autopilot/services/autopilot.service.ts
@@ -33,6 +33,7 @@ import {
   SCREENING_PHASE_NAMES,
   APPROVAL_PHASE_NAMES,
   PHASE_ROLE_MAP,
+  AI_SCREENING_PHASE_NAME,
 } from '../constants/review.constants';
 import { ReviewService } from '../../review/review.service';
 import { ResourcesService } from '../../resources/resources.service';
@@ -756,9 +757,8 @@ export class AutopilotService {
         return;
       }
 
-      // Import AI_SCREENING_PHASE_NAME from constants if needed
       const aiScreeningPhase = challenge.phases.find(
-        (p) => p.name === 'AI Screening',
+        (p) => p.name === AI_SCREENING_PHASE_NAME,
       );
 
       if (!aiScreeningPhase) {

--- a/src/autopilot/services/phase-review.service.spec.ts
+++ b/src/autopilot/services/phase-review.service.spec.ts
@@ -123,6 +123,8 @@ describe('PhaseReviewService', () => {
       getExistingReviewPairs: jest.fn(),
       createPendingReview: jest.fn(),
       getFailedScreeningSubmissionIds: jest.fn(),
+      getAiFailedDecisionSubmissionIds: jest.fn(),
+      markSubmissionsAsAiFailedReview: jest.fn(),
       getCheckpointPassedSubmissionIds: jest.fn(),
       generateReviewSummaries: jest.fn(),
     } as unknown as jest.Mocked<ReviewService>;
@@ -173,6 +175,10 @@ describe('PhaseReviewService', () => {
     reviewService.getFailedScreeningSubmissionIds.mockResolvedValue(
       new Set(),
     );
+    reviewService.getAiFailedDecisionSubmissionIds.mockResolvedValue(
+      new Set(),
+    );
+    reviewService.markSubmissionsAsAiFailedReview.mockResolvedValue(0);
     reviewService.generateReviewSummaries.mockResolvedValue([]);
     reviewService.getActiveCheckpointSubmissionIds.mockResolvedValue([]);
     challengeCompletionService.finalizeChallenge.mockResolvedValue(true);
@@ -387,6 +393,42 @@ describe('PhaseReviewService', () => {
       );
 
     expect(createdSubmissionIds).toEqual(['passed-submission']);
+  });
+
+  it('locks and skips submissions that failed AI review decisions', async () => {
+    const challenge = buildChallenge({});
+    challengeApiService.getChallengeById.mockResolvedValue(challenge);
+
+    const submissions: ActiveContestSubmission[] = [
+      { id: 'ai-failed-submission', memberId: '123', isLatest: true },
+      { id: 'eligible-submission', memberId: '456', isLatest: true },
+    ];
+
+    reviewService.getActiveContestSubmissions.mockResolvedValue(submissions);
+    reviewService.getAiFailedDecisionSubmissionIds.mockResolvedValue(
+      new Set(['ai-failed-submission']),
+    );
+    reviewService.markSubmissionsAsAiFailedReview.mockResolvedValue(1);
+
+    await service.handlePhaseOpened(challenge.id, basePhase.id);
+
+    expect(
+      reviewService.getAiFailedDecisionSubmissionIds,
+    ).toHaveBeenCalledWith(challenge.id, [
+      'ai-failed-submission',
+      'eligible-submission',
+    ]);
+    expect(reviewService.markSubmissionsAsAiFailedReview).toHaveBeenCalledWith(
+      challenge.id,
+      ['ai-failed-submission'],
+    );
+
+    const createdSubmissionIds =
+      reviewService.createPendingReview.mock.calls.map(
+        (callArgs) => callArgs[0],
+      );
+
+    expect(createdSubmissionIds).toEqual(['eligible-submission']);
   });
 
   it('creates post-mortem pending reviews for Post-Mortem Reviewer resources', async () => {

--- a/src/autopilot/services/phase-review.service.ts
+++ b/src/autopilot/services/phase-review.service.ts
@@ -479,6 +479,13 @@ export class PhaseReviewService {
       );
     }
 
+    if (submissionIds.length && isReviewPhase) {
+      submissionIds = await this.excludeAiFailedReviewSubmissions(
+        challengeId,
+        submissionIds,
+      );
+    }
+
     if (!submissionIds.length) {
       this.logPhaseAction('INFO', challengeId, {
         phaseId: phase.id,
@@ -604,6 +611,55 @@ export class PhaseReviewService {
       const err = error as Error;
       this.logger.error(
         `Failed to filter screened submissions for challenge ${challenge.id}: ${err.message}`,
+        err.stack,
+      );
+      return submissionIds;
+    }
+  }
+
+  private async excludeAiFailedReviewSubmissions(
+    challengeId: string,
+    submissionIds: string[],
+  ): Promise<string[]> {
+    if (!submissionIds.length) {
+      return submissionIds;
+    }
+
+    try {
+      const aiFailedIds =
+        await this.reviewService.getAiFailedDecisionSubmissionIds(
+          challengeId,
+          submissionIds,
+        );
+
+      if (!aiFailedIds.size) {
+        return submissionIds;
+      }
+
+      const lockedSubmissionIds = submissionIds.filter((id) =>
+        aiFailedIds.has(id),
+      );
+
+      if (!lockedSubmissionIds.length) {
+        return submissionIds;
+      }
+
+      await this.reviewService.markSubmissionsAsAiFailedReview(
+        challengeId,
+        lockedSubmissionIds,
+      );
+
+      const filtered = submissionIds.filter((id) => !aiFailedIds.has(id));
+
+      this.logger.log(
+        `Excluded ${lockedSubmissionIds.length} submission(s) for challenge ${challengeId} due to failed AI review decisions.`,
+      );
+
+      return filtered;
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        `Failed to filter AI review decision submissions for challenge ${challengeId}: ${err.message}`,
         err.stack,
       );
       return submissionIds;

--- a/src/autopilot/services/phase-schedule-manager.service.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.ts
@@ -1313,7 +1313,6 @@ export class PhaseScheduleManager {
             operator: AutopilotOperator.SYSTEM_PHASE_CHAIN,
             projectStatus,
             date: new Date().toISOString(),
-            skipReviewCompletionCheck: true,
           };
 
           await this.schedulerService.advancePhase(closePayload);

--- a/src/autopilot/services/phase-schedule-manager.service.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.ts
@@ -16,6 +16,7 @@ import {
   PhaseTransitionPayload,
 } from '../interfaces/autopilot.interface';
 import {
+  AI_SCREENING_PHASE_NAME,
   APPROVAL_PHASE_NAMES,
   DEFAULT_APPEALS_PHASE_NAMES,
   DEFAULT_APPEALS_RESPONSE_PHASE_NAMES,
@@ -1286,6 +1287,47 @@ export class PhaseScheduleManager {
       }
     }
 
+    if (this.isAiScreeningPhaseName(updatedPhase.name)) {
+      try {
+        const challenge =
+          await this.challengeApiService.getChallengeById(challengeId);
+        const aiWorkflowIds = this.getAiWorkflowIdsForChallenge(challenge);
+
+        const inProgressAiWorkflows =
+          await this.reviewService.getInProgressAiWorkflowRunCount(
+            challengeId,
+            aiWorkflowIds,
+          );
+
+        if (inProgressAiWorkflows === 0) {
+          this.logger.log(
+            `[AI SCREENING] No pending AI workflow runs for challenge ${challengeId}; closing phase ${updatedPhase.id} immediately after open.`,
+          );
+
+          const closePayload: PhaseTransitionPayload = {
+            projectId,
+            challengeId,
+            phaseId: updatedPhase.id,
+            phaseTypeName: updatedPhase.name,
+            state: 'END',
+            operator: AutopilotOperator.SYSTEM_PHASE_CHAIN,
+            projectStatus,
+            date: new Date().toISOString(),
+            skipReviewCompletionCheck: true,
+          };
+
+          await this.schedulerService.advancePhase(closePayload);
+          return true;
+        }
+      } catch (error) {
+        const err = error as Error;
+        this.logger.error(
+          `[AI SCREENING] Unable to evaluate pending AI workflow runs for challenge ${challengeId}, phase ${updatedPhase.id}: ${err.message}`,
+          err.stack,
+        );
+      }
+    }
+
     const nextPhaseData: PhaseTransitionPayload = {
       projectId,
       challengeId,
@@ -1327,5 +1369,19 @@ export class PhaseScheduleManager {
     }
 
     return this.appealsPhaseNames.has(normalized);
+  }
+
+  private isAiScreeningPhaseName(phaseName?: string | null): boolean {
+    return phaseName?.trim() === AI_SCREENING_PHASE_NAME;
+  }
+
+  private getAiWorkflowIdsForChallenge(challenge: IChallenge): string[] {
+    return Array.from(
+      new Set(
+        (challenge.reviewers ?? [])
+          .map((reviewer) => reviewer.aiWorkflowId)
+          .filter((workflowId): workflowId is string => Boolean(workflowId)),
+      ),
+    );
   }
 }

--- a/src/autopilot/services/scheduler.service.spec.ts
+++ b/src/autopilot/services/scheduler.service.spec.ts
@@ -51,6 +51,9 @@ type ReviewServiceMock = {
   getFailedScreeningSubmissionIds: MockedMethod<ReviewService['getFailedScreeningSubmissionIds']>;
   getPassedScreeningSubmissionIds: MockedMethod<ReviewService['getPassedScreeningSubmissionIds']>;
   getCompletedReviewCountForPhase: MockedMethod<ReviewService['getCompletedReviewCountForPhase']>;
+  getInProgressAiWorkflowRunCount: MockedMethod<
+    ReviewService['getInProgressAiWorkflowRunCount']
+  >;
 };
 
 type KafkaServiceMock = {
@@ -181,6 +184,8 @@ describe('SchedulerService (review phase deferral)', () => {
         createMockMethod<ReviewService['getPassedScreeningSubmissionIds']>(),
       getCompletedReviewCountForPhase:
         createMockMethod<ReviewService['getCompletedReviewCountForPhase']>(),
+      getInProgressAiWorkflowRunCount:
+        createMockMethod<ReviewService['getInProgressAiWorkflowRunCount']>(),
     };
     reviewService.getTotalAppealCount.mockResolvedValue(1);
     reviewService.getPendingAppealCount.mockResolvedValue(0);
@@ -193,6 +198,7 @@ describe('SchedulerService (review phase deferral)', () => {
     reviewService.getPassedScreeningSubmissionIds.mockResolvedValue(
       new Set(),
     );
+    reviewService.getInProgressAiWorkflowRunCount.mockResolvedValue(0);
 
     resourcesService = {
       hasSubmitterResource: jest.fn().mockResolvedValue(true),
@@ -388,6 +394,116 @@ describe('SchedulerService (review phase deferral)', () => {
     await scheduler.advancePhase(payload);
 
     expect(reviewService.getPendingReviewCount).toHaveBeenCalled();
+    expect(challengeApiService.advancePhase).toHaveBeenCalledWith(
+      payload.challengeId,
+      payload.phaseId,
+      'close',
+    );
+  });
+
+  it('defers closing AI Screening when AI workflows are in progress', async () => {
+    const payload = createPayload({
+      phaseId: 'ai-screening-phase',
+      phaseTypeName: 'AI Screening',
+    });
+    const phaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: true,
+    });
+
+    challengeApiService.getPhaseDetails.mockResolvedValue(phaseDetails);
+    challengeApiService.getChallengeById.mockResolvedValue({
+      id: payload.challengeId,
+      phases: [phaseDetails],
+      reviewers: [
+        {
+          id: 'reviewer-config-ai',
+          scorecardId: 'scorecard-ai',
+          isMemberReview: false,
+          memberReviewerCount: 0,
+          phaseId: 'ai-screening-template',
+          fixedAmount: null,
+          baseCoefficient: null,
+          incrementalCoefficient: null,
+          type: null,
+          aiWorkflowId: 'workflow-ai-1',
+          shouldOpenOpportunity: false,
+        },
+      ],
+      legacy: {},
+    } as unknown as IChallenge);
+    reviewService.getInProgressAiWorkflowRunCount.mockResolvedValue(3);
+
+    const scheduleSpy = jest
+      .spyOn(scheduler, 'schedulePhaseTransition')
+      .mockResolvedValue('rescheduled');
+
+    await scheduler.advancePhase(payload);
+
+    expect(challengeApiService.advancePhase).not.toHaveBeenCalled();
+    expect(reviewService.getInProgressAiWorkflowRunCount).toHaveBeenCalledWith(
+      payload.challengeId,
+      ['workflow-ai-1'],
+    );
+    expect(scheduleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes AI Screening when no AI workflows are in progress', async () => {
+    const payload = createPayload({
+      phaseId: 'ai-screening-phase',
+      phaseTypeName: 'AI Screening',
+    });
+    const phaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: true,
+    });
+
+    challengeApiService.getPhaseDetails.mockResolvedValue(phaseDetails);
+    challengeApiService.getChallengeById.mockResolvedValue({
+      id: payload.challengeId,
+      phases: [phaseDetails],
+      reviewers: [
+        {
+          id: 'reviewer-config-ai',
+          scorecardId: 'scorecard-ai',
+          isMemberReview: false,
+          memberReviewerCount: 0,
+          phaseId: 'ai-screening-template',
+          fixedAmount: null,
+          baseCoefficient: null,
+          incrementalCoefficient: null,
+          type: null,
+          aiWorkflowId: 'workflow-ai-1',
+          shouldOpenOpportunity: false,
+        },
+      ],
+      legacy: {},
+    } as unknown as IChallenge);
+    reviewService.getInProgressAiWorkflowRunCount.mockResolvedValue(0);
+    challengeApiService.advancePhase.mockResolvedValue({
+      success: true,
+      message: 'closed ai screening',
+      updatedPhases: [
+        createPhase({
+          id: payload.phaseId,
+          phaseId: 'ai-screening-template',
+          name: 'AI Screening',
+          isOpen: false,
+          actualEndDate: new Date().toISOString(),
+        }),
+      ],
+    });
+
+    await scheduler.advancePhase(payload);
+
+    expect(reviewService.getInProgressAiWorkflowRunCount).toHaveBeenCalledWith(
+      payload.challengeId,
+      ['workflow-ai-1'],
+    );
     expect(challengeApiService.advancePhase).toHaveBeenCalledWith(
       payload.challengeId,
       payload.phaseId,

--- a/src/autopilot/services/scheduler.service.spec.ts
+++ b/src/autopilot/services/scheduler.service.spec.ts
@@ -511,6 +511,256 @@ describe('SchedulerService (review phase deferral)', () => {
     );
   });
 
+  it('auto-closes AI Screening phase immediately when no AI workflows are in progress on open', async () => {
+    const payload = createPayload({
+      state: 'START',
+      phaseId: 'ai-screening-phase',
+      phaseTypeName: 'AI Screening',
+    });
+
+    const closedPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: false,
+    });
+    const openPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: true,
+    });
+
+    challengeApiService.getPhaseDetails
+      .mockResolvedValueOnce(closedPhaseDetails)
+      .mockResolvedValueOnce(openPhaseDetails);
+
+    challengeApiService.getChallengeById.mockResolvedValue({
+      id: payload.challengeId,
+      phases: [closedPhaseDetails],
+      reviewers: [
+        {
+          id: 'reviewer-config-ai',
+          scorecardId: 'scorecard-ai',
+          isMemberReview: false,
+          memberReviewerCount: 0,
+          phaseId: 'ai-screening-template',
+          fixedAmount: null,
+          baseCoefficient: null,
+          incrementalCoefficient: null,
+          type: null,
+          aiWorkflowId: 'workflow-ai-1',
+          shouldOpenOpportunity: false,
+        },
+      ],
+      legacy: {},
+    } as unknown as IChallenge);
+
+    reviewService.getInProgressAiWorkflowRunCount.mockResolvedValue(0);
+
+    const openResponse: Awaited<
+      ReturnType<ChallengeApiService['advancePhase']>
+    > = {
+      success: true,
+      message: 'opened ai screening',
+      updatedPhases: [
+        createPhase({
+          id: payload.phaseId,
+          phaseId: 'ai-screening-template',
+          name: 'AI Screening',
+          isOpen: true,
+          actualStartDate: new Date().toISOString(),
+        }),
+      ],
+    };
+
+    const closeResponse: Awaited<
+      ReturnType<ChallengeApiService['advancePhase']>
+    > = {
+      success: true,
+      message: 'closed ai screening',
+      updatedPhases: [
+        createPhase({
+          id: payload.phaseId,
+          phaseId: 'ai-screening-template',
+          name: 'AI Screening',
+          isOpen: false,
+          actualEndDate: new Date().toISOString(),
+        }),
+      ],
+    };
+
+    challengeApiService.advancePhase
+      .mockResolvedValueOnce(openResponse)
+      .mockResolvedValueOnce(closeResponse);
+
+    await scheduler.advancePhase(payload);
+
+    expect(challengeApiService.advancePhase).toHaveBeenNthCalledWith(
+      1,
+      payload.challengeId,
+      payload.phaseId,
+      'open',
+    );
+    expect(reviewService.getInProgressAiWorkflowRunCount).toHaveBeenCalledWith(
+      payload.challengeId,
+      ['workflow-ai-1'],
+    );
+    expect(challengeApiService.advancePhase).toHaveBeenNthCalledWith(
+      2,
+      payload.challengeId,
+      payload.phaseId,
+      'close',
+    );
+  });
+
+  it('keeps AI Screening phase open when AI workflows are in progress on open', async () => {
+    const payload = createPayload({
+      state: 'START',
+      phaseId: 'ai-screening-phase',
+      phaseTypeName: 'AI Screening',
+    });
+
+    const closedPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: false,
+    });
+    const openPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: true,
+    });
+
+    challengeApiService.getPhaseDetails
+      .mockResolvedValueOnce(closedPhaseDetails)
+      .mockResolvedValueOnce(openPhaseDetails);
+
+    challengeApiService.getChallengeById.mockResolvedValue({
+      id: payload.challengeId,
+      phases: [closedPhaseDetails],
+      reviewers: [
+        {
+          id: 'reviewer-config-ai',
+          scorecardId: 'scorecard-ai',
+          isMemberReview: false,
+          memberReviewerCount: 0,
+          phaseId: 'ai-screening-template',
+          fixedAmount: null,
+          baseCoefficient: null,
+          incrementalCoefficient: null,
+          type: null,
+          aiWorkflowId: 'workflow-ai-1',
+          shouldOpenOpportunity: false,
+        },
+      ],
+      legacy: {},
+    } as unknown as IChallenge);
+
+    reviewService.getInProgressAiWorkflowRunCount.mockResolvedValue(3);
+
+    const openResponse: Awaited<
+      ReturnType<ChallengeApiService['advancePhase']>
+    > = {
+      success: true,
+      message: 'opened ai screening',
+      updatedPhases: [
+        createPhase({
+          id: payload.phaseId,
+          phaseId: 'ai-screening-template',
+          name: 'AI Screening',
+          isOpen: true,
+          actualStartDate: new Date().toISOString(),
+        }),
+      ],
+    };
+
+    challengeApiService.advancePhase.mockResolvedValueOnce(openResponse);
+
+    await scheduler.advancePhase(payload);
+
+    expect(challengeApiService.advancePhase).toHaveBeenCalledTimes(1);
+    expect(challengeApiService.advancePhase).toHaveBeenCalledWith(
+      payload.challengeId,
+      payload.phaseId,
+      'open',
+    );
+    expect(reviewService.getInProgressAiWorkflowRunCount).toHaveBeenCalledWith(
+      payload.challengeId,
+      ['workflow-ai-1'],
+    );
+    // Should not auto-close since there are in-progress workflows
+    expect(challengeApiService.advancePhase).not.toHaveBeenCalledWith(
+      payload.challengeId,
+      payload.phaseId,
+      'close',
+    );
+  });
+
+  it('continues opening AI Screening phase when workflow check fails', async () => {
+    const payload = createPayload({
+      state: 'START',
+      phaseId: 'ai-screening-phase',
+      phaseTypeName: 'AI Screening',
+    });
+
+    const closedPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: false,
+    });
+    const openPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: true,
+    });
+
+    challengeApiService.getPhaseDetails
+      .mockResolvedValueOnce(closedPhaseDetails)
+      .mockResolvedValueOnce(openPhaseDetails);
+
+    challengeApiService.getChallengeById.mockRejectedValue(
+      new Error('Failed to fetch challenge'),
+    );
+
+    const openResponse: Awaited<
+      ReturnType<ChallengeApiService['advancePhase']>
+    > = {
+      success: true,
+      message: 'opened ai screening',
+      updatedPhases: [
+        createPhase({
+          id: payload.phaseId,
+          phaseId: 'ai-screening-template',
+          name: 'AI Screening',
+          isOpen: true,
+          actualStartDate: new Date().toISOString(),
+        }),
+      ],
+    };
+
+    challengeApiService.advancePhase.mockResolvedValueOnce(openResponse);
+
+    await scheduler.advancePhase(payload);
+
+    expect(challengeApiService.advancePhase).toHaveBeenCalledTimes(1);
+    expect(challengeApiService.advancePhase).toHaveBeenCalledWith(
+      payload.challengeId,
+      payload.phaseId,
+      'open',
+    );
+    // Should not attempt to auto-close on error
+    expect(challengeApiService.advancePhase).not.toHaveBeenCalledWith(
+      payload.challengeId,
+      payload.phaseId,
+      'close',
+    );
+  });
+
   it('refreshes submissions when iterative review closes', async () => {
     const payload = createPayload({
       phaseTypeName: ITERATIVE_REVIEW_PHASE_NAME,

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -131,7 +131,6 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     private readonly first2FinishService: First2FinishService,
   ) {
     this.phaseChainCallback = SchedulerService.phaseChainCallback;
-    SchedulerService.phaseChainCallback = null;
     this.submitterRoles = getNormalizedStringArray(
       this.configService.get('autopilot.submitterRoles'),
       ['Submitter'],
@@ -274,6 +273,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     ) => Promise<void> | void,
   ): void {
     SchedulerService.phaseChainCallback = callback;
+    this.phaseChainCallback = callback;
     Logger.log(
       `[PHASE CHAIN] Phase chain callback registered (pid ${process.pid}).`,
       SchedulerService.name,

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -59,6 +59,14 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(SchedulerService.name);
   private topgearPostMortemLocks = new Set<string>();
   private scheduledJobs = new Map<string, PhaseTransitionPayload>();
+  private static phaseChainCallback:
+    | ((
+        challengeId: string,
+        projectId: number,
+        projectStatus: string,
+        nextPhases: any[],
+      ) => Promise<void> | void)
+    | null = null;
   private phaseChainCallback:
     | ((
         challengeId: string,
@@ -120,6 +128,8 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     @Inject(forwardRef(() => First2FinishService))
     private readonly first2FinishService: First2FinishService,
   ) {
+    this.phaseChainCallback = SchedulerService.phaseChainCallback;
+    SchedulerService.phaseChainCallback = null;
     this.submitterRoles = getNormalizedStringArray(
       this.configService.get('autopilot.submitterRoles'),
       ['Submitter'],
@@ -216,25 +226,6 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
 
     try {
       await this.initializationPromise;
-
-      // Wait for phase chain callback (with timeout)
-      const callbackTimeout = 30000; // 30 seconds
-      const startTime = Date.now();
-      while (!this.phaseChainCallbackInitialized && Date.now() - startTime < callbackTimeout) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-      }
-
-      if (!this.phaseChainCallbackInitialized) {
-        this.logger.error(
-          `[LIFECYCLE] Phase chain callback was not registered within ${callbackTimeout}ms. ` +
-          `This indicates a service initialization issue. Phase chaining will not work.`,
-        );
-        throw new Error('Phase chain callback not registered - service initialization failed');
-      }
-
-      this.logger.log(
-        `[LIFECYCLE] SchedulerService fully initialized with phase chain callback (pid ${process.pid}).`,
-      );
     } catch (error) {
       const err = error as Error;
       this.logger.error(
@@ -280,8 +271,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       nextPhases: any[],
     ) => Promise<void> | void,
   ): void {
-    this.phaseChainCallback = callback;
-      this.phaseChainCallbackInitialized = true;
+    SchedulerService.phaseChainCallback = callback;
     Logger.log(
       `[PHASE CHAIN] Phase chain callback registered (pid ${process.pid}).`,
       SchedulerService.name,

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -1068,6 +1068,46 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
           }
         }
 
+        if (operation === 'open' && isAiScreeningPhase) {
+          try {
+            const challenge =
+              await this.challengeApiService.getChallengeById(data.challengeId);
+            const aiWorkflowIds = this.getAiWorkflowIdsForPhase(
+              challenge,
+              phaseDetails,
+            );
+
+            const inProgressAiWorkflows =
+              await this.reviewService.getInProgressAiWorkflowRunCount(
+                data.challengeId,
+                aiWorkflowIds,
+              );
+
+            if (inProgressAiWorkflows === 0) {
+              this.logger.log(
+                `[AI SCREENING] No pending AI workflow runs for challenge ${data.challengeId}; closing phase ${data.phaseId} immediately after open.`,
+              );
+
+              const closePayload: PhaseTransitionPayload = {
+                ...data,
+                state: 'END',
+                operator: data.operator ?? AutopilotOperator.SYSTEM_SCHEDULER,
+                date: new Date().toISOString(),
+                skipReviewCompletionCheck: true,
+              };
+
+              await this.advancePhase(closePayload);
+              return;
+            }
+          } catch (error) {
+            const err = error as Error;
+            this.logger.error(
+              `[AI SCREENING] Unable to evaluate pending AI workflow runs for challenge ${data.challengeId}, phase ${data.phaseId}: ${err.message}`,
+              err.stack,
+            );
+          }
+        }
+
         if (operation === 'close') {
           if (phaseName === SUBMISSION_PHASE_NAME) {
             try {

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -1093,7 +1093,6 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
                 state: 'END',
                 operator: data.operator ?? AutopilotOperator.SYSTEM_SCHEDULER,
                 date: new Date().toISOString(),
-                skipReviewCompletionCheck: true,
               };
 
               await this.advancePhase(closePayload);

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -67,6 +67,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
         nextPhases: any[],
       ) => Promise<void> | void)
     | null = null;
+  private phaseChainCallbackInitialized = false;
   private finalizationRetryTimers = new Map<string, NodeJS.Timeout>();
   private finalizationAttempts = new Map<string, number>();
   private readonly finalizationRetryBaseDelayMs = 60_000;
@@ -215,6 +216,25 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
 
     try {
       await this.initializationPromise;
+
+      // Wait for phase chain callback (with timeout)
+      const callbackTimeout = 30000; // 30 seconds
+      const startTime = Date.now();
+      while (!this.phaseChainCallbackInitialized && Date.now() - startTime < callbackTimeout) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+
+      if (!this.phaseChainCallbackInitialized) {
+        this.logger.error(
+          `[LIFECYCLE] Phase chain callback was not registered within ${callbackTimeout}ms. ` +
+          `This indicates a service initialization issue. Phase chaining will not work.`,
+        );
+        throw new Error('Phase chain callback not registered - service initialization failed');
+      }
+
+      this.logger.log(
+        `[LIFECYCLE] SchedulerService fully initialized with phase chain callback (pid ${process.pid}).`,
+      );
     } catch (error) {
       const err = error as Error;
       this.logger.error(
@@ -261,6 +281,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     ) => Promise<void> | void,
   ): void {
     this.phaseChainCallback = callback;
+      this.phaseChainCallbackInitialized = true;
     Logger.log(
       `[PHASE CHAIN] Phase chain callback registered (pid ${process.pid}).`,
       SchedulerService.name,

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -696,10 +696,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
           const challenge = await this.challengeApiService.getChallengeById(
             data.challengeId,
           );
-          const aiWorkflowIds = this.getAiWorkflowIdsForPhase(
-            challenge,
-            phaseDetails,
-          );
+          const aiWorkflowIds = this.getAiWorkflowIds(challenge);
 
           const inProgressAiWorkflows =
             await this.reviewService.getInProgressAiWorkflowRunCount(
@@ -1132,12 +1129,10 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
 
         if (operation === 'open' && isAiScreeningPhase) {
           try {
-            const challenge =
-              await this.challengeApiService.getChallengeById(data.challengeId);
-            const aiWorkflowIds = this.getAiWorkflowIdsForPhase(
-              challenge,
-              phaseDetails,
+            const challenge = await this.challengeApiService.getChallengeById(
+              data.challengeId,
             );
+            const aiWorkflowIds = this.getAiWorkflowIds(challenge);
 
             const inProgressAiWorkflows =
               await this.reviewService.getInProgressAiWorkflowRunCount(
@@ -2394,30 +2389,10 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     return `${challengeId}|${phaseId}|ai-screening-close`;
   }
 
-  private getAiWorkflowIdsForPhase(
-    challenge: IChallenge,
-    phase: IPhase,
-  ): string[] {
-    const challengePhase = challenge.phases?.find(
-      (candidate) => candidate.id === phase.id,
-    );
-    // const phaseTemplateId = challengePhase?.phaseId ?? phase.phaseId ?? null;
-
+  private getAiWorkflowIds(challenge: IChallenge): string[] {
     return Array.from(
       new Set(
         (challenge.reviewers ?? [])
-          // we don't actually care about ai review phaseId, they always run
-          // .filter((reviewer) => {
-          //   if (!reviewer.aiWorkflowId) {
-          //     return false;
-          //   }
-
-          //   if (!phaseTemplateId) {
-          //     return true;
-          //   }
-
-          //   return reviewer.phaseId === phaseTemplateId;
-          // })
           .map((reviewer) => reviewer.aiWorkflowId)
           .filter((workflowId): workflowId is string => Boolean(workflowId)),
       ),

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -22,6 +22,7 @@ import { Job, Queue, RedisOptions, Worker } from 'bullmq';
 import { ChallengeStatusEnum } from '@prisma/client';
 import { ReviewService } from '../../review/review.service';
 import {
+  AI_SCREENING_PHASE_NAME,
   POST_MORTEM_REVIEWER_ROLE_NAME,
   REGISTRATION_PHASE_NAME,
   REVIEW_PHASE_NAMES,
@@ -89,6 +90,9 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
   private readonly approvalCloseRetryAttempts = new Map<string, number>();
   private readonly approvalCloseRetryBaseDelayMs = 10 * 60 * 1000;
   private readonly approvalCloseRetryMaxDelayMs = 60 * 60 * 1000;
+  private readonly aiScreeningCloseRetryAttempts = new Map<string, number>();
+  private readonly aiScreeningCloseRetryBaseDelayMs = 10 * 60 * 1000;
+  private readonly aiScreeningCloseRetryMaxDelayMs = 60 * 60 * 1000;
   private readonly submitterRoles: string[];
   private readonly postMortemRoles: string[];
   private readonly postMortemScorecardId: string | null;
@@ -501,6 +505,9 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       const isScreeningPhase =
         SCREENING_PHASE_NAMES.has(phaseName) ||
         SCREENING_PHASE_NAMES.has(data.phaseTypeName);
+      const isAiScreeningPhase =
+        phaseName === AI_SCREENING_PHASE_NAME ||
+        data.phaseTypeName === AI_SCREENING_PHASE_NAME;
       const isApprovalPhase =
         APPROVAL_PHASE_NAMES.has(phaseName) ||
         APPROVAL_PHASE_NAMES.has(data.phaseTypeName);
@@ -643,6 +650,47 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
             data,
             undefined,
             'unable to verify review readiness',
+          );
+          return;
+        }
+      }
+
+      // Block closing AI Screening until all configured AI workflows are completed
+      if (operation === 'close' && isAiScreeningPhase) {
+        try {
+          const challenge = await this.challengeApiService.getChallengeById(
+            data.challengeId,
+          );
+          const aiWorkflowIds = this.getAiWorkflowIdsForPhase(
+            challenge,
+            phaseDetails,
+          );
+
+          const inProgressAiWorkflows =
+            await this.reviewService.getInProgressAiWorkflowRunCount(
+              data.challengeId,
+              aiWorkflowIds,
+            );
+
+          if (inProgressAiWorkflows > 0) {
+            await this.deferAiScreeningPhaseClosure(
+              data,
+              inProgressAiWorkflows,
+              `${inProgressAiWorkflows} in-progress AI workflow run(s) detected`,
+            );
+            return;
+          }
+        } catch (error) {
+          const err = error as Error;
+          this.logger.error(
+            `[AI SCREENING LATE] Unable to verify AI workflow readiness for phase ${data.phaseId} on challenge ${data.challengeId}: ${err.message}`,
+            err.stack,
+          );
+
+          await this.deferAiScreeningPhaseClosure(
+            data,
+            undefined,
+            'unable to verify AI workflow readiness',
           );
           return;
         }
@@ -943,6 +991,12 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
         if (operation === 'close' && isApprovalPhase) {
           this.approvalCloseRetryAttempts.delete(
             this.buildApprovalPhaseKey(data.challengeId, data.phaseId),
+          );
+        }
+
+        if (operation === 'close' && isAiScreeningPhase) {
+          this.aiScreeningCloseRetryAttempts.delete(
+            this.buildAiScreeningPhaseKey(data.challengeId, data.phaseId),
           );
         }
 
@@ -2189,6 +2243,93 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     phaseId: string,
   ): string {
     return `${challengeId}|${phaseId}|screening-close`;
+  }
+
+  private async deferAiScreeningPhaseClosure(
+    data: PhaseTransitionPayload,
+    pendingCount?: number,
+    reason?: string,
+  ): Promise<void> {
+    const key = this.buildAiScreeningPhaseKey(data.challengeId, data.phaseId);
+    const attempt = (this.aiScreeningCloseRetryAttempts.get(key) ?? 0) + 1;
+    this.aiScreeningCloseRetryAttempts.set(key, attempt);
+
+    const delay = this.computeAiScreeningCloseRetryDelay(attempt);
+    const nextRun = new Date(Date.now() + delay).toISOString();
+
+    const payload: PhaseTransitionPayload = {
+      ...data,
+      date: nextRun,
+      operator: data.operator ?? AutopilotOperator.SYSTEM_SCHEDULER,
+    };
+
+    try {
+      await this.schedulePhaseTransition(payload);
+      const pendingDescription =
+        typeof pendingCount === 'number' && pendingCount >= 0
+          ? pendingCount
+          : 'unknown';
+
+      const reasonMessage =
+        reason ?? `${pendingDescription} in-progress AI workflow run(s) detected`;
+
+      this.logger.warn(
+        `[AI SCREENING LATE] Deferred closing AI screening phase ${data.phaseId} for challenge ${data.challengeId}; ${reasonMessage}. Retrying in ${Math.round(delay / 60000)} minute(s).`,
+      );
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        `[AI SCREENING LATE] Failed to reschedule close for AI screening phase ${data.phaseId} on challenge ${data.challengeId}: ${err.message}`,
+        err.stack,
+      );
+      this.aiScreeningCloseRetryAttempts.delete(key);
+      throw err;
+    }
+  }
+
+  private computeAiScreeningCloseRetryDelay(attempt: number): number {
+    return this.computeBackoffDelay(
+      attempt,
+      this.aiScreeningCloseRetryBaseDelayMs,
+      this.aiScreeningCloseRetryMaxDelayMs,
+    );
+  }
+
+  private buildAiScreeningPhaseKey(
+    challengeId: string,
+    phaseId: string,
+  ): string {
+    return `${challengeId}|${phaseId}|ai-screening-close`;
+  }
+
+  private getAiWorkflowIdsForPhase(
+    challenge: IChallenge,
+    phase: IPhase,
+  ): string[] {
+    const challengePhase = challenge.phases?.find(
+      (candidate) => candidate.id === phase.id,
+    );
+    // const phaseTemplateId = challengePhase?.phaseId ?? phase.phaseId ?? null;
+
+    return Array.from(
+      new Set(
+        (challenge.reviewers ?? [])
+          // we don't actually care about ai review phaseId, they always run
+          // .filter((reviewer) => {
+          //   if (!reviewer.aiWorkflowId) {
+          //     return false;
+          //   }
+
+          //   if (!phaseTemplateId) {
+          //     return true;
+          //   }
+
+          //   return reviewer.phaseId === phaseTemplateId;
+          // })
+          .map((reviewer) => reviewer.aiWorkflowId)
+          .filter((workflowId): workflowId is string => Boolean(workflowId)),
+      ),
+    );
   }
 
   private async deferApprovalPhaseClosure(

--- a/src/kafka/constants/topics.ts
+++ b/src/kafka/constants/topics.ts
@@ -9,6 +9,7 @@ export const KAFKA_TOPICS = {
   RESOURCE_DELETED: 'challenge.action.resource.delete',
   REVIEW_COMPLETED: 'review.action.completed',
   REVIEW_APPEAL_RESPONDED: 'review.action.appeal.responded',
+  AI_WORKFLOW_COMPLETED: 'aiworkflow.action.completed',
   FIRST2FINISH_SUBMISSION_RECEIVED: 'first2finish.submission.received',
   TOPGEAR_SUBMISSION_RECEIVED: 'topgear.submission.received',
 } as const;

--- a/src/kafka/consumers/autopilot.consumer.ts
+++ b/src/kafka/consumers/autopilot.consumer.ts
@@ -14,6 +14,7 @@ import {
   ResourceEventPayload,
   ReviewCompletedPayload,
   SubmissionAggregatePayload,
+  AiWorkflowCompletedPayload,
 } from 'src/autopilot/interfaces/autopilot.interface';
 
 @Injectable()
@@ -70,6 +71,10 @@ export class AutopilotConsumer {
         this.autopilotService.handleAppealResponded.bind(
           this.autopilotService,
         ) as (message: AppealRespondedPayload) => Promise<void>,
+      [KAFKA_TOPICS.AI_WORKFLOW_COMPLETED]:
+        this.autopilotService.handleAiWorkflowCompleted.bind(
+          this.autopilotService,
+        ) as (message: AiWorkflowCompletedPayload) => Promise<void>,
       [KAFKA_TOPICS.FIRST2FINISH_SUBMISSION_RECEIVED]:
         this.autopilotService.handleFirst2FinishSubmission.bind(
           this.autopilotService,
@@ -136,6 +141,11 @@ export class AutopilotConsumer {
             case KAFKA_TOPICS.REVIEW_APPEAL_RESPONDED:
               await this.autopilotService.handleAppealResponded(
                 payload as AppealRespondedPayload,
+              );
+              break;
+            case KAFKA_TOPICS.AI_WORKFLOW_COMPLETED:
+              await this.autopilotService.handleAiWorkflowCompleted(
+                payload as AiWorkflowCompletedPayload,
               );
               break;
             case KAFKA_TOPICS.FIRST2FINISH_SUBMISSION_RECEIVED:

--- a/src/kafka/types/topic-payload-map.type.ts
+++ b/src/kafka/types/topic-payload-map.type.ts
@@ -9,6 +9,7 @@ import {
   ResourceEventPayload,
   ReviewCompletedPayload,
   SubmissionAggregatePayload,
+  AiWorkflowCompletedPayload,
 } from 'src/autopilot/interfaces/autopilot.interface';
 
 export type TopicPayloadMap = {
@@ -22,6 +23,7 @@ export type TopicPayloadMap = {
   [KAFKA_TOPICS.RESOURCE_DELETED]: ResourceEventPayload;
   [KAFKA_TOPICS.REVIEW_COMPLETED]: ReviewCompletedPayload;
   [KAFKA_TOPICS.REVIEW_APPEAL_RESPONDED]: AppealRespondedPayload;
+  [KAFKA_TOPICS.AI_WORKFLOW_COMPLETED]: AiWorkflowCompletedPayload;
   [KAFKA_TOPICS.FIRST2FINISH_SUBMISSION_RECEIVED]: First2FinishSubmissionPayload;
   [KAFKA_TOPICS.TOPGEAR_SUBMISSION_RECEIVED]: TopgearSubmissionPayload;
 };

--- a/src/review/review.service.spec.ts
+++ b/src/review/review.service.spec.ts
@@ -231,6 +231,98 @@ describe('ReviewService', () => {
     });
   });
 
+  describe('getAiFailedDecisionSubmissionIds', () => {
+    it('returns empty set when no submission ids are provided', async () => {
+      const result = await service.getAiFailedDecisionSubmissionIds(
+        challengeId,
+        [],
+      );
+
+      expect(result).toEqual(new Set());
+      expect(prismaMock.$queryRaw).not.toHaveBeenCalled();
+    });
+
+    it('returns failed submission ids when ai decision status is FAILED or ERROR', async () => {
+      prismaMock.$queryRaw.mockResolvedValueOnce([
+        { submissionId: 'submission-1' },
+        { submissionId: 'submission-2' },
+      ]);
+
+      const result = await service.getAiFailedDecisionSubmissionIds(
+        challengeId,
+        ['submission-1', 'submission-2', 'submission-3'],
+      );
+
+      expect(result).toEqual(new Set(['submission-1', 'submission-2']));
+      expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(1);
+
+      const rawQuery = prismaMock.$queryRaw.mock.calls[0][0] as {
+        strings?: TemplateStringsArray | string[];
+      };
+      const sqlText = Array.isArray(rawQuery?.strings)
+        ? rawQuery.strings.join('')
+        : '';
+
+      expect(sqlText).toContain('"aiReviewDecision"');
+      expect(sqlText).toContain('"aiReviewConfig"');
+      expect(sqlText).toContain("'FAILED', 'ERROR'");
+
+      expect(dbLoggerMock.logAction).toHaveBeenCalledWith(
+        'review.getAiFailedDecisionSubmissionIds',
+        expect.objectContaining({
+          status: 'SUCCESS',
+          details: expect.objectContaining({
+            evaluatedSubmissionCount: 3,
+            aiFailedSubmissionCount: 2,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('markSubmissionsAsAiFailedReview', () => {
+    it('returns 0 when submission ids are missing', async () => {
+      const result = await service.markSubmissionsAsAiFailedReview(
+        challengeId,
+        [],
+      );
+
+      expect(result).toBe(0);
+      expect(prismaMock.$executeRaw).not.toHaveBeenCalled();
+    });
+
+    it('updates submission status to AI_FAILED_REVIEW and logs success', async () => {
+      prismaMock.$executeRaw.mockResolvedValueOnce(2);
+
+      const result = await service.markSubmissionsAsAiFailedReview(
+        challengeId,
+        ['submission-1', 'submission-2'],
+      );
+
+      expect(result).toBe(2);
+      expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1);
+
+      const rawQuery = prismaMock.$executeRaw.mock.calls[0][0] as {
+        strings?: TemplateStringsArray | string[];
+      };
+      const sqlText = Array.isArray(rawQuery?.strings)
+        ? rawQuery.strings.join('')
+        : '';
+      expect(sqlText).toContain("'AI_FAILED_REVIEW'");
+
+      expect(dbLoggerMock.logAction).toHaveBeenCalledWith(
+        'review.markSubmissionsAsAiFailedReview',
+        expect.objectContaining({
+          status: 'SUCCESS',
+          details: expect.objectContaining({
+            submissionCount: 2,
+            updatedCount: 2,
+          }),
+        }),
+      );
+    });
+  });
+
   describe('updatePendingReviewScorecards', () => {
     const phaseId = 'phase-1';
     const scorecardId = 'scorecard-123';

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -82,6 +82,7 @@ export interface SubmissionSummary {
 export class ReviewService {
   private static readonly REVIEW_TABLE = Prisma.sql`"review"`;
   private static readonly SUBMISSION_TABLE = Prisma.sql`"submission"`;
+  private static readonly AI_WORKFLOW_RUN_TABLE = Prisma.sql`"aiWorkflowRun"`;
   private static readonly REVIEW_SUMMATION_TABLE = Prisma.sql`"reviewSummation"`;
   private static readonly SCORECARD_TABLE = Prisma.sql`"scorecard"`;
   private static readonly REVIEW_TYPE_TABLE = Prisma.sql`"reviewType"`;
@@ -1031,6 +1032,77 @@ export class ReviewService {
         source: ReviewService.name,
         details: {
           phaseId,
+          error: err.message,
+        },
+      });
+      throw err;
+    }
+  }
+
+  async getInProgressAiWorkflowRunCount(
+    challengeId: string,
+    workflowIds: string[],
+  ): Promise<number> {
+    const normalizedWorkflowIds = Array.from(
+      new Set(
+        (workflowIds ?? [])
+          .map((workflowId) => workflowId?.trim())
+          .filter((workflowId): workflowId is string => Boolean(workflowId)),
+      ),
+    );
+
+    if (!challengeId || normalizedWorkflowIds.length === 0) {
+      return 0;
+    }
+
+    const query = Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM ${ReviewService.AI_WORKFLOW_RUN_TABLE} run
+      INNER JOIN ${ReviewService.SUBMISSION_TABLE} submission
+        ON submission."id" = run."submissionId"
+      WHERE submission."challengeId" = ${challengeId}
+        AND run."workflowId" IN (${Prisma.join(normalizedWorkflowIds)})
+        AND run."completedAt" IS NULL
+        AND (
+          run."status" IS NULL
+          OR UPPER((run."status")::text) NOT IN (
+            'COMPLETED',
+            'FAILED',
+            'ERROR',
+            'CANCELLED',
+            'CANCELED',
+            'SKIPPED',
+            'TIMED_OUT',
+            'SUCCESS',
+            'DONE'
+          )
+        )
+    `;
+
+    try {
+      const [record] = await this.prisma.$queryRaw<PendingCountRecord[]>(query);
+      const rawCount = Number(record?.count ?? 0);
+      const count = Number.isFinite(rawCount) ? rawCount : 0;
+
+      void this.dbLogger.logAction('review.getInProgressAiWorkflowRunCount', {
+        challengeId,
+        status: 'SUCCESS',
+        source: ReviewService.name,
+        details: {
+          workflowCount: normalizedWorkflowIds.length,
+          inProgressCount: count,
+        },
+      });
+
+      return count;
+    } catch (error) {
+      const err = error as Error;
+      void this.dbLogger.logAction('review.getInProgressAiWorkflowRunCount', {
+        challengeId,
+        status: 'ERROR',
+        source: ReviewService.name,
+        details: {
+          workflowCount: normalizedWorkflowIds.length,
           error: err.message,
         },
       });

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -8,6 +8,10 @@ interface SubmissionRecord {
   id: string;
 }
 
+interface AiFailedDecisionRecord {
+  submissionId: string;
+}
+
 export interface ActiveContestSubmission {
   id: string;
   memberId: string | null;
@@ -82,7 +86,8 @@ export interface SubmissionSummary {
 export class ReviewService {
   private static readonly REVIEW_TABLE = Prisma.sql`"review"`;
   private static readonly SUBMISSION_TABLE = Prisma.sql`"submission"`;
-  private static readonly AI_WORKFLOW_RUN_TABLE = Prisma.sql`"aiWorkflowRun"`;
+  private static readonly AI_REVIEW_CONFIG_TABLE = Prisma.sql`"aiReviewConfig"`;
+  private static readonly AI_REVIEW_DECISION_TABLE = Prisma.sql`"aiReviewDecision"`;
   private static readonly REVIEW_SUMMATION_TABLE = Prisma.sql`"reviewSummation"`;
   private static readonly SCORECARD_TABLE = Prisma.sql`"scorecard"`;
   private static readonly REVIEW_TYPE_TABLE = Prisma.sql`"reviewType"`;
@@ -817,6 +822,145 @@ export class ReviewService {
     }
   }
 
+  async getAiFailedDecisionSubmissionIds(
+    challengeId: string,
+    submissionIds: string[],
+  ): Promise<Set<string>> {
+    const uniqueSubmissionIds = Array.from(
+      new Set(
+        submissionIds
+          .map((id) => id?.trim())
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    if (!challengeId || !uniqueSubmissionIds.length) {
+      return new Set();
+    }
+
+    const submissionList = Prisma.join(
+      uniqueSubmissionIds.map((id) => Prisma.sql`${id}`),
+    );
+
+    const query = Prisma.sql`
+      WITH ranked_decisions AS (
+        SELECT
+          d."submissionId" AS "submissionId",
+          UPPER((d."status")::text) AS "decisionStatus",
+          ROW_NUMBER() OVER (
+            PARTITION BY d."submissionId"
+            ORDER BY
+              c."version" DESC,
+              COALESCE(d."finalizedAt", d."updatedAt", d."createdAt") DESC,
+              d."id" DESC
+          ) AS "decisionRank"
+        FROM ${ReviewService.AI_REVIEW_DECISION_TABLE} d
+        INNER JOIN ${ReviewService.AI_REVIEW_CONFIG_TABLE} c
+          ON c."id" = d."configId"
+        WHERE c."challengeId" = ${challengeId}
+          AND d."submissionId" IN (${submissionList})
+      )
+      SELECT "submissionId"
+      FROM ranked_decisions
+      WHERE "decisionRank" = 1
+        AND "decisionStatus" IN ('FAILED', 'ERROR')
+    `;
+
+    try {
+      const rows =
+        await this.prisma.$queryRaw<AiFailedDecisionRecord[]>(query);
+      const failedIds = new Set(
+        rows.map((record) => record.submissionId).filter(Boolean),
+      );
+
+      void this.dbLogger.logAction('review.getAiFailedDecisionSubmissionIds', {
+        challengeId,
+        status: 'SUCCESS',
+        source: ReviewService.name,
+        details: {
+          evaluatedSubmissionCount: uniqueSubmissionIds.length,
+          aiFailedSubmissionCount: failedIds.size,
+        },
+      });
+
+      return failedIds;
+    } catch (error) {
+      const err = error as Error;
+      void this.dbLogger.logAction('review.getAiFailedDecisionSubmissionIds', {
+        challengeId,
+        status: 'ERROR',
+        source: ReviewService.name,
+        details: {
+          evaluatedSubmissionCount: uniqueSubmissionIds.length,
+          error: err.message,
+        },
+      });
+      throw err;
+    }
+  }
+
+  async markSubmissionsAsAiFailedReview(
+    challengeId: string,
+    submissionIds: string[],
+  ): Promise<number> {
+    const uniqueSubmissionIds = Array.from(
+      new Set(
+        submissionIds
+          .map((id) => id?.trim())
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    if (!challengeId || !uniqueSubmissionIds.length) {
+      return 0;
+    }
+
+    const submissionList = Prisma.join(
+      uniqueSubmissionIds.map((id) => Prisma.sql`${id}`),
+    );
+
+    const query = Prisma.sql`
+      UPDATE ${ReviewService.SUBMISSION_TABLE}
+      SET
+        "status" = 'AI_FAILED_REVIEW',
+        "updatedAt" = NOW()
+      WHERE "challengeId" = ${challengeId}
+        AND "id" IN (${submissionList})
+        AND (
+          "status" IS NULL
+          OR UPPER(("status")::text) = 'ACTIVE'
+        )
+    `;
+
+    try {
+      const updated = await this.prisma.$executeRaw(query);
+
+      void this.dbLogger.logAction('review.markSubmissionsAsAiFailedReview', {
+        challengeId,
+        status: 'SUCCESS',
+        source: ReviewService.name,
+        details: {
+          submissionCount: uniqueSubmissionIds.length,
+          updatedCount: updated,
+        },
+      });
+
+      return updated;
+    } catch (error) {
+      const err = error as Error;
+      void this.dbLogger.logAction('review.markSubmissionsAsAiFailedReview', {
+        challengeId,
+        status: 'ERROR',
+        source: ReviewService.name,
+        details: {
+          submissionCount: uniqueSubmissionIds.length,
+          error: err.message,
+        },
+      });
+      throw err;
+    }
+  }
+
   async getPassedScreeningSubmissionIds(
     challengeId: string,
     screeningScorecardIds: string[],
@@ -1032,77 +1176,6 @@ export class ReviewService {
         source: ReviewService.name,
         details: {
           phaseId,
-          error: err.message,
-        },
-      });
-      throw err;
-    }
-  }
-
-  async getInProgressAiWorkflowRunCount(
-    challengeId: string,
-    workflowIds: string[],
-  ): Promise<number> {
-    const normalizedWorkflowIds = Array.from(
-      new Set(
-        (workflowIds ?? [])
-          .map((workflowId) => workflowId?.trim())
-          .filter((workflowId): workflowId is string => Boolean(workflowId)),
-      ),
-    );
-
-    if (!challengeId || normalizedWorkflowIds.length === 0) {
-      return 0;
-    }
-
-    const query = Prisma.sql`
-      SELECT COUNT(*)::int AS count
-      FROM ${ReviewService.AI_WORKFLOW_RUN_TABLE} run
-      INNER JOIN ${ReviewService.SUBMISSION_TABLE} submission
-        ON submission."id" = run."submissionId"
-      WHERE submission."challengeId" = ${challengeId}
-        AND run."workflowId" IN (${Prisma.join(normalizedWorkflowIds)})
-        AND run."completedAt" IS NULL
-        AND (
-          run."status" IS NULL
-          OR UPPER((run."status")::text) NOT IN (
-            'COMPLETED',
-            'FAILED',
-            'ERROR',
-            'CANCELLED',
-            'CANCELED',
-            'SKIPPED',
-            'TIMED_OUT',
-            'SUCCESS',
-            'DONE'
-          )
-        )
-    `;
-
-    try {
-      const [record] = await this.prisma.$queryRaw<PendingCountRecord[]>(query);
-      const rawCount = Number(record?.count ?? 0);
-      const count = Number.isFinite(rawCount) ? rawCount : 0;
-
-      void this.dbLogger.logAction('review.getInProgressAiWorkflowRunCount', {
-        challengeId,
-        status: 'SUCCESS',
-        source: ReviewService.name,
-        details: {
-          workflowCount: normalizedWorkflowIds.length,
-          inProgressCount: count,
-        },
-      });
-
-      return count;
-    } catch (error) {
-      const err = error as Error;
-      void this.dbLogger.logAction('review.getInProgressAiWorkflowRunCount', {
-        challengeId,
-        status: 'ERROR',
-        source: ReviewService.name,
-        details: {
-          workflowCount: normalizedWorkflowIds.length,
           error: err.message,
         },
       });

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -95,6 +95,7 @@ export class ReviewService {
   private static readonly APPEAL_RESPONSE_TABLE = Prisma.sql`"appealResponse"`;
   private static readonly REVIEW_ITEM_COMMENT_TABLE = Prisma.sql`"reviewItemComment"`;
   private static readonly REVIEW_ITEM_TABLE = Prisma.sql`"reviewItem"`;
+  private static readonly AI_WORKFLOW_RUN_TABLE = Prisma.sql`"aiWorkflowRun"`;
   private static readonly FINAL_REVIEW_TYPE_NAMES = new Set<string>([
     'REVIEW',
     'REGULAR REVIEW',
@@ -2136,6 +2137,65 @@ export class ReviewService {
         status: 'ERROR',
         source: ReviewService.name,
         details: {
+          error: err.message,
+        },
+      });
+      throw err;
+    }
+  }
+
+  async getInProgressAiWorkflowRunCount(
+    challengeId: string,
+    aiWorkflowIds: string[],
+  ): Promise<number> {
+    const normalizedWorkflowIds = Array.from(
+      new Set(
+        (aiWorkflowIds ?? [])
+          .map((workflowId) => workflowId?.trim())
+          .filter((workflowId): workflowId is string => Boolean(workflowId)),
+      ),
+    );
+
+    if (!challengeId || normalizedWorkflowIds.length === 0) {
+      return 0;
+    }
+
+    const inProgressStatuses = ['INIT', 'QUEUED', 'DISPATCHED', 'IN_PROGRESS'];
+
+    const query = Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM ${ReviewService.AI_WORKFLOW_RUN_TABLE} awr
+      INNER JOIN ${ReviewService.SUBMISSION_TABLE} s
+        ON s."id" = awr."submissionId"
+      WHERE s."challengeId" = ${challengeId}
+        AND awr."workflowId" IN (${Prisma.join(normalizedWorkflowIds)})
+        AND UPPER((awr."status")::text) IN (${Prisma.join(inProgressStatuses)})
+    `;
+
+    try {
+      const [record] = await this.prisma.$queryRaw<PendingCountRecord[]>(query);
+      const rawCount = Number(record?.count ?? 0);
+      const count = Number.isFinite(rawCount) ? rawCount : 0;
+
+      void this.dbLogger.logAction('review.getInProgressAiWorkflowRunCount', {
+        challengeId,
+        status: 'SUCCESS',
+        source: ReviewService.name,
+        details: {
+          workflowCount: normalizedWorkflowIds.length,
+          inProgressCount: count,
+        },
+      });
+
+      return count;
+    } catch (error) {
+      const err = error as Error;
+      void this.dbLogger.logAction('review.getInProgressAiWorkflowRunCount', {
+        challengeId,
+        status: 'ERROR',
+        source: ReviewService.name,
+        details: {
+          workflowCount: normalizedWorkflowIds.length,
           error: err.message,
         },
       });


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-3926

Added support for "AI Screening" phase in the workflow, enabling automated handling of submissions and phase transitions based on AI workflow completion. The changes add new constants, interfaces, and logic to manage AI workflow runs, automatically close the AI Screening phase when all AI workflows are complete, and filter out submissions that failed AI review decisions. Several tests are updated or added to ensure these behaviors are correctly implemented.

- Added logic in `phase-schedule-manager.service.ts` to automatically close the AI Screening phase if there are no pending AI workflow runs when the phase opens, including helper methods for identifying the phase and retrieving workflow IDs.
- implemented the `handleAiWorkflowCompleted` method in `autopilot.service.ts`, which closes the AI Screening phase early when all AI workflows are finished.
- new Kafka topic added `aiworkflow.action.completed` - this will be triggered by the review api when all ai workflwos have been completed
- Added logic in `phase-review.service.ts` to exclude and lock submissions that failed AI review decisions from further review
- Updated and expanded tests in `phase-review.service.spec.ts` to mock new review service methods and verify that submissions failing AI review decisions are properly excluded and locked. 
- Added mocks and test setup for `getInProgressAiWorkflowRunCount` in `scheduler.service.spec.ts` to support new AI workflow logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/autopilot-v6/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
