### PR TITLE
PM-3926 ai screening phase

### DIFF
--- a/src/autopilot/services/first2finish.service.ts
+++ b/src/autopilot/services/first2finish.service.ts
@@ -14,6 +14,7 @@ import {
 } from '../interfaces/autopilot.interface';
 import {
   ITERATIVE_REVIEW_PHASE_NAME,
+  AI_SCREENING_PHASE_NAME,
   PHASE_ROLE_MAP,
   REGISTRATION_PHASE_NAME,
   SUBMISSION_PHASE_NAME,
@@ -286,6 +287,18 @@ export class First2FinishService {
     }
 
     const latestIterativePhase = this.getLatestIterativePhase(challenge);
+
+    // If an AI Screening phase exists and hasn't completed yet, wait for it to finish
+    const aiScreeningPending = (challenge.phases ?? []).some(
+      (p) => p.name === AI_SCREENING_PHASE_NAME && !p.actualEndDate,
+    );
+    if (aiScreeningPending) {
+      this.logger.debug(
+        `Awaiting AI Screening completion for challenge ${challenge.id} before processing iterative review.`,
+        { submissionId: submissionId ?? null },
+      );
+      return;
+    }
 
     if (!latestIterativePhase) {
       this.logger.warn(
@@ -633,6 +646,17 @@ export class First2FinishService {
     const latestIterativePhase = this.getLatestIterativePhase(challenge);
 
     if (!latestIterativePhase) {
+      return;
+    }
+
+    // If an AI Screening phase exists and hasn't completed yet, wait for it to finish
+    const aiScreeningPending = (challenge.phases ?? []).some(
+      (p) => p.name === AI_SCREENING_PHASE_NAME && !p.actualEndDate,
+    );
+    if (aiScreeningPending) {
+      this.logger.debug(
+        `Awaiting AI Screening completion for challenge ${challenge.id} before preparing next iterative review.`,
+      );
       return;
     }
 

--- a/src/autopilot/services/phase-review.service.spec.ts
+++ b/src/autopilot/services/phase-review.service.spec.ts
@@ -389,7 +389,14 @@ describe('PhaseReviewService', () => {
   });
 
   it('locks and skips submissions that failed AI review decisions', async () => {
+    const aiScreeningPhase = {
+      ...basePhase,
+      id: 'phase-ai-screening',
+      phaseId: 'template-ai-screening',
+      name: 'AI Screening',
+    };
     const challenge = buildChallenge({});
+    challenge.phases = [aiScreeningPhase, { ...basePhase }];
     challengeApiService.getChallengeById.mockResolvedValue(challenge);
 
     const submissions: ActiveContestSubmission[] = [
@@ -422,6 +429,159 @@ describe('PhaseReviewService', () => {
       );
 
     expect(createdSubmissionIds).toEqual(['eligible-submission']);
+  });
+
+  it('skips all screening reviews when no submissions have passed AI screening', async () => {
+    const aiScreeningPhase = {
+      ...basePhase,
+      id: 'phase-ai-screening',
+      phaseId: 'template-ai-screening',
+      name: 'AI Screening',
+    };
+    const screeningPhase = {
+      ...basePhase,
+      id: 'phase-screening',
+      phaseId: 'template-screening',
+      name: 'Screening',
+    };
+
+    const challenge = buildChallenge({});
+    challenge.phases = [aiScreeningPhase, screeningPhase];
+    challenge.reviewers = [
+      {
+        id: 'screening-config',
+        scorecardId: 'screening-scorecard',
+        isMemberReview: false,
+        memberReviewerCount: 1,
+        phaseId: screeningPhase.phaseId,
+        baseCoefficient: null,
+        incrementalCoefficient: null,
+        type: null,
+        aiWorkflowId: null,
+        shouldOpenOpportunity: true,
+      },
+    ];
+
+    challengeApiService.getChallengeById.mockResolvedValue(challenge);
+
+    const submissions: ActiveContestSubmission[] = [
+      { id: 'submission-1', memberId: '123', isLatest: true },
+      { id: 'submission-2', memberId: '456', isLatest: true },
+    ];
+    reviewService.getActiveContestSubmissions.mockResolvedValue(submissions);
+    reviewService.getAiFailedDecisionSubmissionIds.mockResolvedValue(
+      new Set(['submission-1', 'submission-2']),
+    );
+
+    await service.handlePhaseOpened(challenge.id, screeningPhase.id);
+
+    expect(reviewService.getAiFailedDecisionSubmissionIds).toHaveBeenCalledWith(
+      challenge.id,
+      ['submission-1', 'submission-2'],
+    );
+    expect(reviewService.createPendingReview).not.toHaveBeenCalled();
+  });
+
+  it('creates screening reviews only for submissions that passed AI screening', async () => {
+    const aiScreeningPhase = {
+      ...basePhase,
+      id: 'phase-ai-screening',
+      phaseId: 'template-ai-screening',
+      name: 'AI Screening',
+    };
+    const screeningPhase = {
+      ...basePhase,
+      id: 'phase-screening',
+      phaseId: 'template-screening',
+      name: 'Screening',
+    };
+
+    const challenge = buildChallenge({});
+    challenge.phases = [aiScreeningPhase, screeningPhase];
+    challenge.reviewers = [
+      {
+        id: 'screening-config',
+        scorecardId: 'screening-scorecard',
+        isMemberReview: false,
+        memberReviewerCount: 1,
+        phaseId: screeningPhase.phaseId,
+        baseCoefficient: null,
+        incrementalCoefficient: null,
+        type: null,
+        aiWorkflowId: null,
+        shouldOpenOpportunity: true,
+      },
+    ];
+
+    challengeApiService.getChallengeById.mockResolvedValue(challenge);
+
+    const submissions: ActiveContestSubmission[] = [
+      { id: 'ai-passed-submission', memberId: '123', isLatest: true },
+      { id: 'ai-failed-submission', memberId: '456', isLatest: true },
+    ];
+    reviewService.getActiveContestSubmissions.mockResolvedValue(submissions);
+    reviewService.getAiFailedDecisionSubmissionIds.mockResolvedValue(
+      new Set(['ai-failed-submission']),
+    );
+
+    await service.handlePhaseOpened(challenge.id, screeningPhase.id);
+
+    expect(reviewService.getAiFailedDecisionSubmissionIds).toHaveBeenCalledWith(
+      challenge.id,
+      ['ai-passed-submission', 'ai-failed-submission'],
+    );
+
+    const createdSubmissionIds =
+      reviewService.createPendingReview.mock.calls.map(
+        (callArgs) => callArgs[0],
+      );
+    expect(createdSubmissionIds).toEqual(['ai-passed-submission']);
+  });
+
+  it('does not apply AI screening filter when challenge has no AI Screening phase', async () => {
+    const screeningPhase = {
+      ...basePhase,
+      id: 'phase-screening',
+      phaseId: 'template-screening',
+      name: 'Screening',
+    };
+
+    const challenge = buildChallenge({});
+    challenge.phases = [screeningPhase];
+    challenge.reviewers = [
+      {
+        id: 'screening-config',
+        scorecardId: 'screening-scorecard',
+        isMemberReview: false,
+        memberReviewerCount: 1,
+        phaseId: screeningPhase.phaseId,
+        baseCoefficient: null,
+        incrementalCoefficient: null,
+        type: null,
+        aiWorkflowId: null,
+        shouldOpenOpportunity: true,
+      },
+    ];
+
+    challengeApiService.getChallengeById.mockResolvedValue(challenge);
+
+    const submissions: ActiveContestSubmission[] = [
+      { id: 'submission-1', memberId: '123', isLatest: true },
+      { id: 'submission-2', memberId: '456', isLatest: true },
+    ];
+    reviewService.getActiveContestSubmissions.mockResolvedValue(submissions);
+
+    await service.handlePhaseOpened(challenge.id, screeningPhase.id);
+
+    expect(reviewService.getAiFailedDecisionSubmissionIds).not.toHaveBeenCalled();
+
+    const createdSubmissionIds =
+      reviewService.createPendingReview.mock.calls.map(
+        (callArgs) => callArgs[0],
+      );
+    expect(createdSubmissionIds).toEqual(
+      expect.arrayContaining(['submission-1', 'submission-2']),
+    );
   });
 
   it('creates post-mortem pending reviews for Post-Mortem Reviewer resources', async () => {

--- a/src/autopilot/services/phase-review.service.spec.ts
+++ b/src/autopilot/services/phase-review.service.spec.ts
@@ -118,6 +118,7 @@ describe('PhaseReviewService', () => {
     reviewService = {
       getActiveContestSubmissions: jest.fn(),
       getActiveCheckpointSubmissionIds: jest.fn(),
+      deleteStalePendingSubmissionReviews: jest.fn(),
       getExistingReviewPairs: jest.fn(),
       createPendingReview: jest.fn(),
       getFailedScreeningSubmissionIds: jest.fn(),
@@ -153,6 +154,7 @@ describe('PhaseReviewService', () => {
     } as unknown as jest.Mocked<AutopilotDbLoggerService>;
 
     reviewService.getExistingReviewPairs.mockResolvedValue(new Set());
+    reviewService.deleteStalePendingSubmissionReviews.mockResolvedValue(0);
     resourcesService.getReviewerResources.mockResolvedValue([
       {
         id: 'resource-1',
@@ -221,6 +223,13 @@ describe('PhaseReviewService', () => {
       );
 
     expect(createdSubmissionIds).toEqual([
+      'latest-submission',
+      'unique-submission',
+    ]);
+
+    expect(
+      reviewService.deleteStalePendingSubmissionReviews,
+    ).toHaveBeenCalledWith(challenge.phases[0].id, challenge.id, [
       'latest-submission',
       'unique-submission',
     ]);

--- a/src/autopilot/services/phase-review.service.ts
+++ b/src/autopilot/services/phase-review.service.ts
@@ -16,6 +16,7 @@ import {
   isPostMortemPhaseName,
   POST_MORTEM_REVIEWER_ROLE_NAME,
   ITERATIVE_REVIEW_PHASE_NAME,
+  AI_SCREENING_PHASE_NAME,
 } from '../constants/review.constants';
 import {
   getMemberReviewerConfigs,
@@ -466,19 +467,24 @@ export class PhaseReviewService {
         new Set(filteredSubmissions.map((submission) => submission.id)),
       );
     }
+
+    if (
+      submissionIds.length &&
+      this.challengeHasAiScreeningPhase(challenge) &&
+      (isReviewPhase || phase.name.toLowerCase().includes('screening'))
+    ) {
+      submissionIds = await this.excludeAiFailedReviewSubmissions(
+        challengeId,
+        submissionIds,
+      );
+    }
+
     if (
       submissionIds.length &&
       (isApprovalPhase || (isReviewPhase && phase.name !== 'Checkpoint Review'))
     ) {
       submissionIds = await this.excludeFailedScreeningSubmissions(
         challenge,
-        submissionIds,
-      );
-    }
-
-    if (submissionIds.length && isReviewPhase) {
-      submissionIds = await this.excludeAiFailedReviewSubmissions(
-        challengeId,
         submissionIds,
       );
     }
@@ -568,6 +574,12 @@ export class PhaseReviewService {
       source: PhaseReviewService.name,
       details,
     });
+  }
+
+  private challengeHasAiScreeningPhase(challenge: IChallenge): boolean {
+    return (challenge.phases ?? []).some(
+      (phase) => phase.name === AI_SCREENING_PHASE_NAME,
+    );
   }
 
   private async excludeFailedScreeningSubmissions(

--- a/src/autopilot/services/phase-review.service.ts
+++ b/src/autopilot/services/phase-review.service.ts
@@ -489,6 +489,27 @@ export class PhaseReviewService {
       );
     }
 
+    try {
+      const deletedStaleReviews =
+        await this.reviewService.deleteStalePendingSubmissionReviews(
+          phase.id,
+          challengeId,
+          submissionIds,
+        );
+
+      if (deletedStaleReviews > 0) {
+        this.logger.log(
+          `Deleted ${deletedStaleReviews} stale pending review assignment(s) for challenge ${challengeId}, phase ${phase.id}.`,
+        );
+      }
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        `Failed to delete stale pending reviews for challenge ${challengeId}, phase ${phase.id}: ${err.message}`,
+        err.stack,
+      );
+    }
+
     if (!submissionIds.length) {
       this.logPhaseAction('INFO', challengeId, {
         phaseId: phase.id,

--- a/src/autopilot/services/scheduler.service.spec.ts
+++ b/src/autopilot/services/scheduler.service.spec.ts
@@ -49,6 +49,9 @@ type ChallengeApiServiceMock = {
 type ReviewServiceMock = {
   getPendingReviewCount: MockedMethod<ReviewService['getPendingReviewCount']>;
   getPendingAppealCount: MockedMethod<ReviewService['getPendingAppealCount']>;
+  getPendingAiDecisionsEscalationsCount: MockedMethod<
+    ReviewService['getPendingAiDecisionsEscalationsCount']
+  >;
   getTotalAppealCount: MockedMethod<ReviewService['getTotalAppealCount']>;
   getActiveContestSubmissionIds: MockedMethod<
     ReviewService['getActiveContestSubmissionIds']
@@ -190,6 +193,10 @@ describe('SchedulerService (review phase deferral)', () => {
         createMockMethod<ReviewService['getPendingReviewCount']>(),
       getPendingAppealCount:
         createMockMethod<ReviewService['getPendingAppealCount']>(),
+      getPendingAiDecisionsEscalationsCount:
+        createMockMethod<
+          ReviewService['getPendingAiDecisionsEscalationsCount']
+        >(),
       getTotalAppealCount:
         createMockMethod<ReviewService['getTotalAppealCount']>(),
       getActiveContestSubmissionIds:
@@ -205,6 +212,7 @@ describe('SchedulerService (review phase deferral)', () => {
     };
     reviewService.getTotalAppealCount.mockResolvedValue(1);
     reviewService.getPendingAppealCount.mockResolvedValue(0);
+    reviewService.getPendingAiDecisionsEscalationsCount.mockResolvedValue(0);
     reviewService.getPendingReviewCount.mockResolvedValue(0);
     reviewService.getCompletedReviewCountForPhase.mockResolvedValue(1);
     reviewService.getActiveContestSubmissionIds.mockResolvedValue([]);
@@ -297,7 +305,7 @@ describe('SchedulerService (review phase deferral)', () => {
 
     challengeApiService.getPhaseDetails.mockResolvedValue(phaseDetails);
     reviewService.getPendingReviewCount.mockResolvedValue(0);
-    reviewService.getPendingAppealCount.mockResolvedValue(3);
+    reviewService.getPendingAiDecisionsEscalationsCount.mockResolvedValue(3);
 
     const scheduleSpy = jest
       .spyOn(scheduler, 'schedulePhaseTransition')
@@ -310,7 +318,9 @@ describe('SchedulerService (review phase deferral)', () => {
       payload.phaseId,
       payload.challengeId,
     );
-    expect(reviewService.getPendingAppealCount).toHaveBeenCalledWith(
+    expect(
+      reviewService.getPendingAiDecisionsEscalationsCount,
+    ).toHaveBeenCalledWith(
       payload.challengeId,
     );
     expect(scheduleSpy).toHaveBeenCalledTimes(1);
@@ -540,7 +550,9 @@ describe('SchedulerService (review phase deferral)', () => {
     await scheduler.advancePhase(payload);
 
     expect(reviewService.getPendingReviewCount).toHaveBeenCalled();
-    expect(reviewService.getPendingAppealCount).toHaveBeenCalledWith(
+    expect(
+      reviewService.getPendingAiDecisionsEscalationsCount,
+    ).toHaveBeenCalledWith(
       payload.challengeId,
     );
     expect(challengeApiService.advancePhase).toHaveBeenCalledWith(

--- a/src/autopilot/services/scheduler.service.spec.ts
+++ b/src/autopilot/services/scheduler.service.spec.ts
@@ -286,6 +286,36 @@ describe('SchedulerService (review phase deferral)', () => {
     ).toBeGreaterThan(Date.now());
   });
 
+  it('defers closing review phases when pending escalation requests exist', async () => {
+    const payload = createPayload();
+    const phaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: payload.phaseId,
+      name: 'Review',
+      isOpen: true,
+    });
+
+    challengeApiService.getPhaseDetails.mockResolvedValue(phaseDetails);
+    reviewService.getPendingReviewCount.mockResolvedValue(0);
+    reviewService.getPendingAppealCount.mockResolvedValue(3);
+
+    const scheduleSpy = jest
+      .spyOn(scheduler, 'schedulePhaseTransition')
+      .mockResolvedValue('rescheduled');
+
+    await scheduler.advancePhase(payload);
+
+    expect(challengeApiService.advancePhase).not.toHaveBeenCalled();
+    expect(reviewService.getPendingReviewCount).toHaveBeenCalledWith(
+      payload.phaseId,
+      payload.challengeId,
+    );
+    expect(reviewService.getPendingAppealCount).toHaveBeenCalledWith(
+      payload.challengeId,
+    );
+    expect(scheduleSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('defers closing review phases when no reviewers are defined', async () => {
     const payload = createPayload();
     const phaseDetails = createPhase({
@@ -510,6 +540,9 @@ describe('SchedulerService (review phase deferral)', () => {
     await scheduler.advancePhase(payload);
 
     expect(reviewService.getPendingReviewCount).toHaveBeenCalled();
+    expect(reviewService.getPendingAppealCount).toHaveBeenCalledWith(
+      payload.challengeId,
+    );
     expect(challengeApiService.advancePhase).toHaveBeenCalledWith(
       payload.challengeId,
       payload.phaseId,

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -1066,6 +1066,18 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
           this.aiScreeningCloseRetryAttempts.delete(
             this.buildAiScreeningPhaseKey(data.challengeId, data.phaseId),
           );
+
+          try {
+            await this.first2FinishService.handleSubmissionByChallengeId(
+              data.challengeId,
+            );
+          } catch (error) {
+            const err = error as Error;
+            this.logger.error(
+              `Failed to resume First2Finish processing for challenge ${data.challengeId} after closing AI Screening phase ${data.phaseId}: ${err.message}`,
+              err.stack,
+            );
+          }
         }
 
         if (operation === 'close' && phaseName === REGISTRATION_PHASE_NAME) {
@@ -2372,7 +2384,8 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
           : 'unknown';
 
       const reasonMessage =
-        reason ?? `${pendingDescription} in-progress AI workflow run(s) detected`;
+        reason ??
+        `${pendingDescription} in-progress AI workflow run(s) detected`;
 
       this.logger.warn(
         `[AI SCREENING LATE] Deferred closing AI screening phase ${data.phaseId} for challenge ${data.challengeId}; ${reasonMessage}. Retrying in ${Math.round(delay / 60000)} minute(s).`,

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -674,6 +674,18 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
             await this.deferReviewPhaseClosure(data, pendingReviews);
             return;
           }
+
+          const pendingEscalationRequests =
+            await this.reviewService.getPendingAppealCount(data.challengeId);
+
+          if (pendingEscalationRequests > 0) {
+            await this.deferReviewPhaseClosure(
+              data,
+              pendingEscalationRequests,
+              `${pendingEscalationRequests} pending escalation request(s) detected`,
+            );
+            return;
+          }
         } catch (error) {
           const err = error as Error;
           this.logger.error(

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -676,7 +676,9 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
           }
 
           const pendingEscalationRequests =
-            await this.reviewService.getPendingAppealCount(data.challengeId);
+            await this.reviewService.getPendingAiDecisionsEscalationsCount(
+              data.challengeId,
+            );
 
           if (pendingEscalationRequests > 0) {
             await this.deferReviewPhaseClosure(

--- a/src/review/review.service.spec.ts
+++ b/src/review/review.service.spec.ts
@@ -360,6 +360,59 @@ describe('ReviewService', () => {
     });
   });
 
+  describe('getPendingAiDecisionsEscalationsCount', () => {
+    it('returns pending AI escalation count when query succeeds', async () => {
+      prismaMock.$queryRaw.mockResolvedValueOnce([{ count: '3' }]);
+
+      const result = await service.getPendingAiDecisionsEscalationsCount(
+        challengeId,
+      );
+
+      expect(result).toBe(3);
+      expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(1);
+
+      const rawQuery = prismaMock.$queryRaw.mock.calls[0][0] as {
+        strings?: TemplateStringsArray | string[];
+      };
+      const sqlText = Array.isArray(rawQuery?.strings)
+        ? rawQuery.strings.join('')
+        : '';
+
+      expect(sqlText).toContain('"aiReviewDecisionEscalation"');
+      expect(sqlText).toContain('"aiReviewDecision"');
+      expect(sqlText).toContain('"submission"');
+      expect(sqlText).toContain("'PENDING_APPROVAL'");
+
+      expect(dbLoggerMock.logAction).toHaveBeenCalledWith(
+        'review.getPendingAiDecisionsEscalationsCount',
+        expect.objectContaining({
+          status: 'SUCCESS',
+          details: expect.objectContaining({
+            pendingAiDecisionsEscalations: 3,
+          }),
+        }),
+      );
+    });
+
+    it('logs error and rethrows when query fails', async () => {
+      prismaMock.$queryRaw.mockRejectedValueOnce(new Error('query failed'));
+
+      await expect(
+        service.getPendingAiDecisionsEscalationsCount(challengeId),
+      ).rejects.toThrow('query failed');
+
+      expect(dbLoggerMock.logAction).toHaveBeenCalledWith(
+        'review.getPendingAiDecisionsEscalationsCount',
+        expect.objectContaining({
+          status: 'ERROR',
+          details: expect.objectContaining({
+            error: 'query failed',
+          }),
+        }),
+      );
+    });
+  });
+
   describe('updatePendingReviewScorecards', () => {
     const phaseId = 'phase-1';
     const scorecardId = 'scorecard-123';

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -871,8 +871,7 @@ export class ReviewService {
     `;
 
     try {
-      const rows =
-        await this.prisma.$queryRaw<AiFailedDecisionRecord[]>(query);
+      const rows = await this.prisma.$queryRaw<AiFailedDecisionRecord[]>(query);
       const failedIds = new Set(
         rows.map((record) => record.submissionId).filter(Boolean),
       );

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -88,6 +88,8 @@ export class ReviewService {
   private static readonly SUBMISSION_TABLE = Prisma.sql`"submission"`;
   private static readonly AI_REVIEW_CONFIG_TABLE = Prisma.sql`"aiReviewConfig"`;
   private static readonly AI_REVIEW_DECISION_TABLE = Prisma.sql`"aiReviewDecision"`;
+  private static readonly AI_REVIEW_DECISION_ESCALATION_TABLE =
+    Prisma.sql`"aiReviewDecisionEscalation"`;
   private static readonly REVIEW_SUMMATION_TABLE = Prisma.sql`"reviewSummation"`;
   private static readonly SCORECARD_TABLE = Prisma.sql`"scorecard"`;
   private static readonly REVIEW_TYPE_TABLE = Prisma.sql`"reviewType"`;
@@ -2197,6 +2199,55 @@ export class ReviewService {
           error: err.message,
         },
       });
+      throw err;
+    }
+  }
+
+  async getPendingAiDecisionsEscalationsCount(
+    challengeId: string,
+  ): Promise<number> {
+    const query = Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM ${ReviewService.AI_REVIEW_DECISION_ESCALATION_TABLE} aides
+      INNER JOIN ${ReviewService.AI_REVIEW_DECISION_TABLE} aid
+        ON aid."id" = aides."aiReviewDecisionId"
+      INNER JOIN ${ReviewService.SUBMISSION_TABLE} s
+        ON s."id" = aid."submissionId"
+      WHERE s."challengeId" = ${challengeId}
+        AND aides."status" = 'PENDING_APPROVAL'
+    `;
+
+    try {
+      const [record] = await this.prisma.$queryRaw<PendingCountRecord[]>(query);
+      const rawCount = Number(record?.count ?? 0);
+      const count = Number.isFinite(rawCount) ? rawCount : 0;
+
+      void this.dbLogger.logAction(
+        'review.getPendingAiDecisionsEscalationsCount',
+        {
+          challengeId,
+          status: 'SUCCESS',
+          source: ReviewService.name,
+          details: {
+            pendingAiDecisionsEscalations: count,
+          },
+        },
+      );
+
+      return count;
+    } catch (error) {
+      const err = error as Error;
+      void this.dbLogger.logAction(
+        'review.getPendingAiDecisionsEscalationsCount',
+        {
+          challengeId,
+          status: 'ERROR',
+          source: ReviewService.name,
+          details: {
+            error: err.message,
+          },
+        },
+      );
       throw err;
     }
   }

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -1416,6 +1416,78 @@ export class ReviewService {
     }
   }
 
+  async deleteStalePendingSubmissionReviews(
+    phaseId: string,
+    challengeId: string,
+    allowedSubmissionIds: string[],
+  ): Promise<number> {
+    const trimmedPhaseId = phaseId?.trim();
+
+    if (!trimmedPhaseId || !challengeId) {
+      return 0;
+    }
+
+    const normalizedSubmissionIds = Array.from(
+      new Set(
+        (allowedSubmissionIds ?? [])
+          .map((id) => (typeof id === 'string' ? id.trim() : ''))
+          .filter((id) => id.length > 0),
+      ),
+    );
+
+    const allowedCondition = normalizedSubmissionIds.length
+      ? Prisma.sql`AND "submissionId" NOT IN (
+          ${Prisma.join(normalizedSubmissionIds.map((id) => Prisma.sql`${id}`))}
+        )`
+      : Prisma.sql``;
+
+    const query = Prisma.sql`
+      DELETE FROM ${ReviewService.REVIEW_TABLE}
+      WHERE "phaseId" = ${trimmedPhaseId}
+        AND "submissionId" IS NOT NULL
+        AND "submissionId" IN (
+          SELECT "id"
+          FROM ${ReviewService.SUBMISSION_TABLE}
+          WHERE "challengeId" = ${challengeId}
+        )
+        ${allowedCondition}
+        AND (
+          "status" IS NULL
+          OR UPPER(("status")::text) NOT IN ('COMPLETED', 'NO_REVIEW')
+        )
+    `;
+
+    try {
+      const deleted = await this.prisma.$executeRaw(query);
+
+      void this.dbLogger.logAction('review.deleteStalePendingSubmissionReviews', {
+        challengeId,
+        status: 'SUCCESS',
+        source: ReviewService.name,
+        details: {
+          phaseId: trimmedPhaseId,
+          allowedSubmissionCount: normalizedSubmissionIds.length,
+          deletedCount: deleted,
+        },
+      });
+
+      return deleted;
+    } catch (error) {
+      const err = error as Error;
+      void this.dbLogger.logAction('review.deleteStalePendingSubmissionReviews', {
+        challengeId,
+        status: 'ERROR',
+        source: ReviewService.name,
+        details: {
+          phaseId: trimmedPhaseId,
+          allowedSubmissionCount: normalizedSubmissionIds.length,
+          error: err.message,
+        },
+      });
+      throw err;
+    }
+  }
+
   async reassignPendingReviewsToResource(
     phaseId: string,
     resourceId: string,

--- a/test/autopilot.e2e-spec.ts
+++ b/test/autopilot.e2e-spec.ts
@@ -238,6 +238,7 @@ describe('Autopilot Service (e2e)', () => {
       getScorecardPassingScore: jest.fn().mockResolvedValue(50),
       getCompletedReviewCountForPhase: jest.fn().mockResolvedValue(0),
       getPendingAppealCount: jest.fn().mockResolvedValue(0),
+      getPendingAiDecisionsEscalationsCount: jest.fn().mockResolvedValue(0),
       getActiveSubmissionIds: jest.fn().mockResolvedValue([]),
       generateReviewSummaries: jest.fn().mockResolvedValue([]),
     } satisfies Record<string, jest.Mock>;


### PR DESCRIPTION
Forgot to create PRs previously. most of these changes have already passed QA, they've been deployed as feature branch.

This pull request introduces several important improvements to the challenge review and phase handling logic, focusing on better integration of AI Screening, improved cleanup of stale review assignments, and more robust handling of review phase closure. The changes ensure that phases dependent on AI Screening wait for its completion, submissions failing AI review are filtered out appropriately, and stale review assignments are deleted to prevent inconsistencies. Additionally, review phase closure is now deferred if there are pending escalation requests. Comprehensive tests have been added to validate these behaviors.

Key changes include:

**AI Screening Integration:**

- Added logic to defer processing of iterative review and preparation for the next review phase in `First2FinishService` if an AI Screening phase exists and is not yet completed, ensuring dependent phases do not proceed prematurely.
- Updated `PhaseReviewService` to filter out submissions that failed AI Screening before creating reviews for screening/review phases, but only if the challenge includes an AI Screening phase. 

**Stale Review Assignment Cleanup:**

- Implemented `deleteStalePendingSubmissionReviews` in `ReviewService` to remove pending review assignments for submissions no longer eligible, and integrated its invocation into `PhaseReviewService` before creating new pending reviews.
- Added logging for the number of deleted stale reviews and error handling for failed deletions.

**Review Phase Closure Deferral:**

- Enhanced `SchedulerService` to defer closing review phases if there are pending escalation (appeal) requests, in addition to pending reviews or missing reviewers, improving phase transition robustness.

**Testing Enhancements:**

- Added/updated tests in `phase-review.service.spec.ts` to verify AI Screening integration, stale review deletion, and correct filtering of submissions for review phases. 
- Added tests in `scheduler.service.spec.ts` for review phase closure deferral when escalation requests exist.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/autopilot-v6/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
