### PR TITLE
Fix phase advance check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,8 @@ workflows:
             only:
               - develop
               - reviews
-              - PM-3926_ai-screening-phase
+          tags:
+            only: /^dev-.*/
             
     # Production builds are exectuted only on tagged commits to the
     # master branch.

--- a/src/autopilot/services/autopilot.service.spec.ts
+++ b/src/autopilot/services/autopilot.service.spec.ts
@@ -124,7 +124,10 @@ describe('AutopilotService - handleSubmissionNotificationAggregate', () => {
       createPendingReview: jest.fn(),
     } as unknown as jest.Mocked<ReviewService>;
 
-    reviewService.createPendingReview.mockResolvedValue(false);
+    reviewService.createPendingReview.mockResolvedValue({
+      created: false,
+      reviewId: null,
+    });
 
     resourcesService = {
       getReviewerResources: jest.fn(),
@@ -304,7 +307,10 @@ describe('AutopilotService - handleSubmissionNotificationAggregate', () => {
         roleName: 'Approver',
       },
     ]);
-    reviewService.createPendingReview.mockResolvedValueOnce(true);
+    reviewService.createPendingReview.mockResolvedValueOnce({
+      created: true,
+      reviewId: 'review-1',
+    });
 
     await autopilotService.handleSubmissionNotificationAggregate(
       createPayload({

--- a/src/autopilot/services/phase-review.service.spec.ts
+++ b/src/autopilot/services/phase-review.service.spec.ts
@@ -16,6 +16,7 @@ import {
   ITERATIVE_REVIEW_PHASE_NAME,
 } from '../constants/review.constants';
 import { ReviewSummationApiService } from './review-summation-api.service';
+import { MarathonMatchReviewService } from '../../marathon-match/marathon-match-review.service';
 
 const basePhase = {
   id: 'phase-1',
@@ -99,6 +100,7 @@ describe('PhaseReviewService', () => {
   let configService: jest.Mocked<ConfigService>;
   let challengeCompletionService: jest.Mocked<ChallengeCompletionService>;
   let reviewSummationApiService: jest.Mocked<ReviewSummationApiService>;
+  let marathonMatchReviewService: jest.Mocked<MarathonMatchReviewService>;
   let dbLogger: jest.Mocked<AutopilotDbLoggerService>;
 
   beforeAll(() => {
@@ -118,7 +120,9 @@ describe('PhaseReviewService', () => {
     reviewService = {
       getActiveContestSubmissions: jest.fn(),
       getActiveCheckpointSubmissionIds: jest.fn(),
+      getActiveCheckpointSubmissions: jest.fn(),
       deleteStalePendingSubmissionReviews: jest.fn(),
+      deletePendingReviewsExceptSubmissions: jest.fn(),
       getExistingReviewPairs: jest.fn(),
       createPendingReview: jest.fn(),
       getFailedScreeningSubmissionIds: jest.fn(),
@@ -149,12 +153,16 @@ describe('PhaseReviewService', () => {
     reviewSummationApiService = {
       finalizeSummations: jest.fn().mockResolvedValue(true),
     } as unknown as jest.Mocked<ReviewSummationApiService>;
+    marathonMatchReviewService = {
+      handleReviewPhaseOpened: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<MarathonMatchReviewService>;
     dbLogger = {
       logAction: jest.fn(),
     } as unknown as jest.Mocked<AutopilotDbLoggerService>;
 
     reviewService.getExistingReviewPairs.mockResolvedValue(new Set());
     reviewService.deleteStalePendingSubmissionReviews.mockResolvedValue(0);
+    reviewService.deletePendingReviewsExceptSubmissions.mockResolvedValue(0);
     resourcesService.getReviewerResources.mockResolvedValue([
       {
         id: 'resource-1',
@@ -171,12 +179,16 @@ describe('PhaseReviewService', () => {
         roleName: 'Post-Mortem Reviewer',
       },
     ] as any);
-    reviewService.createPendingReview.mockResolvedValue(true);
+    reviewService.createPendingReview.mockResolvedValue({
+      created: true,
+      reviewId: 'review-1',
+    });
     reviewService.getFailedScreeningSubmissionIds.mockResolvedValue(new Set());
     reviewService.getAiFailedDecisionSubmissionIds.mockResolvedValue(new Set());
     reviewService.markSubmissionsAsAiFailedReview.mockResolvedValue(0);
     reviewService.generateReviewSummaries.mockResolvedValue([]);
     reviewService.getActiveCheckpointSubmissionIds.mockResolvedValue([]);
+    reviewService.getActiveCheckpointSubmissions.mockResolvedValue([]);
     challengeCompletionService.finalizeChallenge.mockResolvedValue(true);
 
     service = new PhaseReviewService(
@@ -184,6 +196,7 @@ describe('PhaseReviewService', () => {
       reviewService,
       resourcesService,
       configService,
+      marathonMatchReviewService,
       challengeCompletionService,
       reviewSummationApiService,
       dbLogger,
@@ -802,6 +815,9 @@ describe('PhaseReviewService', () => {
     challengeApiService.getChallengeById.mockResolvedValue(challenge);
     resourcesService.getReviewerResources.mockResolvedValue([
       { id: 'checkpoint-resource' },
+    ] as any);
+    reviewService.getActiveCheckpointSubmissions.mockResolvedValue([
+      { id: 'submission-1', memberId: '123', isLatest: true },
     ] as any);
     reviewService.getCheckpointPassedSubmissionIds.mockResolvedValue([
       'submission-1',

--- a/src/autopilot/services/phase-schedule-manager.service.spec.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.spec.ts
@@ -3,6 +3,13 @@ import { PhaseScheduleManager } from './phase-schedule-manager.service';
 
 describe('PhaseScheduleManager', () => {
   let service: PhaseScheduleManager;
+  let schedulerService: {
+    setPhaseChainCallback: jest.Mock;
+    evaluateManualPhaseCompletion: jest.Mock;
+  };
+  let phaseReviewService: {
+    handlePhaseOpenedForChallenge: jest.Mock;
+  };
   let challengeApiService: {
     getChallengeById: jest.Mock;
   };
@@ -11,6 +18,15 @@ describe('PhaseScheduleManager', () => {
   };
 
   beforeEach(() => {
+    schedulerService = {
+      setPhaseChainCallback: jest.fn(),
+      evaluateManualPhaseCompletion: jest.fn().mockResolvedValue(undefined),
+    };
+
+    phaseReviewService = {
+      handlePhaseOpenedForChallenge: jest.fn().mockResolvedValue(undefined),
+    };
+
     challengeApiService = {
       getChallengeById: jest.fn(),
     };
@@ -20,11 +36,9 @@ describe('PhaseScheduleManager', () => {
     };
 
     service = new PhaseScheduleManager(
-      {
-        setPhaseChainCallback: jest.fn(),
-      } as any,
+      schedulerService as any,
       challengeApiService as any,
-      {} as any,
+      phaseReviewService as any,
       {} as any,
       {} as any,
       {} as any,
@@ -123,6 +137,80 @@ describe('PhaseScheduleManager', () => {
     );
     expect(financeApiService.generateChallengePayments).toHaveBeenCalledWith(
       'challenge-3',
+    );
+  });
+
+  it('processes unchanged open review phases only once during manual phase detection', async () => {
+    const reviewPhase = {
+      id: 'phase-review-1',
+      phaseId: 'template-review-1',
+      name: 'Review',
+      isOpen: true,
+      actualStartDate: '2026-03-26T10:17:54.388Z',
+      scheduledStartDate: '2026-03-26T10:17:54.388Z',
+      actualEndDate: null,
+      scheduledEndDate: '2026-03-28T10:17:54.388Z',
+    };
+
+    challengeApiService.getChallengeById.mockResolvedValue({
+      id: 'challenge-manual-open-dedupe',
+      status: 'ACTIVE',
+      phases: [reviewPhase],
+      reviewers: [],
+    });
+
+    jest
+      .spyOn(
+        service as unknown as {
+          createReviewOpportunitiesForChallenge: () => Promise<void>;
+        },
+        'createReviewOpportunitiesForChallenge',
+      )
+      .mockResolvedValue(undefined);
+
+    jest
+      .spyOn(
+        service as unknown as {
+          processPastDueOpenPhases: () => Promise<number>;
+        },
+        'processPastDueOpenPhases',
+      )
+      .mockResolvedValue(0);
+
+    jest
+      .spyOn(
+        service as unknown as {
+          scheduleRelevantPhases: () => Promise<void>;
+        },
+        'scheduleRelevantPhases',
+      )
+      .mockResolvedValue(undefined);
+
+    jest
+      .spyOn(
+        service as unknown as {
+          resolveScorecardIdForOpenPhase: () => string | null;
+        },
+        'resolveScorecardIdForOpenPhase',
+      )
+      .mockReturnValue(null);
+
+    const updateMessage = {
+      id: 'challenge-manual-open-dedupe',
+      operator: AutopilotOperator.SYSTEM,
+      projectId: 1003,
+      status: 'ACTIVE',
+    };
+
+    await service.handleChallengeUpdate(updateMessage);
+    await service.handleChallengeUpdate(updateMessage);
+
+    expect(phaseReviewService.handlePhaseOpenedForChallenge).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(phaseReviewService.handlePhaseOpenedForChallenge).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'challenge-manual-open-dedupe' }),
+      'phase-review-1',
     );
   });
 });

--- a/src/autopilot/services/phase-schedule-manager.service.spec.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.spec.ts
@@ -26,6 +26,9 @@ describe('PhaseScheduleManager', () => {
     createReviewOpportunity: jest.Mock;
     getReviewOpportunitiesByChallengeId: jest.Mock;
   };
+  let reviewService: {
+    updatePendingReviewScorecards: jest.Mock;
+  };
   let dbLogger: {
     logAction: jest.Mock;
   };
@@ -52,6 +55,10 @@ describe('PhaseScheduleManager', () => {
       getReviewOpportunitiesByChallengeId: jest.fn().mockResolvedValue([]),
     };
 
+    reviewService = {
+      updatePendingReviewScorecards: jest.fn().mockResolvedValue(0),
+    };
+
     dbLogger = {
       logAction: jest.fn().mockResolvedValue(undefined),
     };
@@ -61,13 +68,11 @@ describe('PhaseScheduleManager', () => {
     };
 
     service = new PhaseScheduleManager(
-      {
-        setPhaseChainCallback: jest.fn(),
-      } as unknown as SchedulerService,
+      schedulerService as unknown as SchedulerService,
       challengeApiService as unknown as ChallengeApiService,
-      {} as unknown as PhaseReviewService,
+      phaseReviewService as unknown as PhaseReviewService,
       {} as unknown as ReviewAssignmentService,
-      {} as unknown as ReviewService,
+      reviewService as unknown as ReviewService,
       reviewApiService as unknown as ReviewApiService,
       {
         get: jest.fn().mockReturnValue(undefined),

--- a/src/autopilot/services/phase-schedule-manager.service.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.ts
@@ -43,6 +43,7 @@ export class PhaseScheduleManager {
   private readonly appealsPhaseNames: Set<string>;
   private readonly appealsResponsePhaseNames: Set<string>;
   private readonly challengeStatusCache: Map<string, string>;
+  private readonly processedOpenPhaseFingerprints: Map<string, string>;
   private static readonly OVERDUE_PHASE_GRACE_PERIOD_MS = 60_000;
   private static readonly PAYABLE_CHALLENGE_STATUSES = new Set([
     'COMPLETED',
@@ -94,6 +95,7 @@ export class PhaseScheduleManager {
     );
 
     this.challengeStatusCache = new Map<string, string>();
+    this.processedOpenPhaseFingerprints = new Map<string, string>();
   }
 
   async schedulePhaseTransition(
@@ -407,6 +409,11 @@ export class PhaseScheduleManager {
       );
 
       if (openPhasesRequiringScorecards.length > 0) {
+        this.pruneOpenPhaseProcessingState(
+          challengeDetails.id,
+          openPhasesRequiringScorecards,
+        );
+
         const phaseNames = openPhasesRequiringScorecards
           .map((phase) => phase.name)
           .join(', ');
@@ -416,6 +423,21 @@ export class PhaseScheduleManager {
 
         let processedCount = 0;
         for (const phase of openPhasesRequiringScorecards) {
+          const phaseKey = this.buildOpenPhaseProcessingKey(
+            challengeDetails.id,
+            phase.id,
+          );
+          const phaseFingerprint = this.buildOpenPhaseFingerprint(phase);
+          const lastProcessedFingerprint =
+            this.processedOpenPhaseFingerprints.get(phaseKey);
+
+          if (lastProcessedFingerprint === phaseFingerprint) {
+            this.logger.debug(
+              `[MANUAL PHASE DETECTION] Skipping unchanged open phase ${phase.id} (${phase.name}) for challenge ${challengeDetails.id}; already processed for current phase-open fingerprint.`,
+            );
+            continue;
+          }
+
           try {
             this.logger.log(
               `[MANUAL PHASE DETECTION] Processing open phase ${phase.id} (${phase.name}) for challenge ${challengeDetails.id}`,
@@ -441,6 +463,10 @@ export class PhaseScheduleManager {
             await this.phaseReviewService.handlePhaseOpenedForChallenge(
               challengeDetails,
               phase.id,
+            );
+            this.processedOpenPhaseFingerprints.set(
+              phaseKey,
+              phaseFingerprint,
             );
             processedCount += 1;
             this.logger.log(
@@ -516,6 +542,40 @@ export class PhaseScheduleManager {
       `[FINANCE] Challenge ${challengeId} transitioned to ${currentStatus}; triggering payment generation.`,
     );
     void this.financeApiService.generateChallengePayments(challengeId);
+  }
+
+  private buildOpenPhaseProcessingKey(
+    challengeId: string,
+    phaseId: string,
+  ): string {
+    return `${challengeId}|${phaseId}`;
+  }
+
+  private buildOpenPhaseFingerprint(phase: IPhase): string {
+    const effectiveStart = phase.actualStartDate ?? phase.scheduledStartDate;
+    const effectiveEnd = phase.actualEndDate ?? 'OPEN';
+    return `${phase.name}|${phase.phaseId}|${phase.isOpen ? 'OPEN' : 'CLOSED'}|${effectiveStart ?? 'UNKNOWN'}|${effectiveEnd}`;
+  }
+
+  private pruneOpenPhaseProcessingState(
+    challengeId: string,
+    openPhases: IPhase[],
+  ): void {
+    const activeKeys = new Set(
+      openPhases.map((phase) =>
+        this.buildOpenPhaseProcessingKey(challengeId, phase.id),
+      ),
+    );
+
+    for (const key of this.processedOpenPhaseFingerprints.keys()) {
+      if (!key.startsWith(`${challengeId}|`)) {
+        continue;
+      }
+
+      if (!activeKeys.has(key)) {
+        this.processedOpenPhaseFingerprints.delete(key);
+      }
+    }
   }
 
   private async createReviewOpportunitiesForChallenge(

--- a/src/autopilot/services/scheduler.service.spec.ts
+++ b/src/autopilot/services/scheduler.service.spec.ts
@@ -247,6 +247,8 @@ describe('SchedulerService (review phase deferral)', () => {
 
     first2FinishService = {
       handleIterativePhaseClosed: jest.fn().mockResolvedValue(undefined),
+      handleSubmissionByChallengeId: jest.fn().mockResolvedValue(undefined),
+      isFirst2FinishChallenge: jest.fn().mockReturnValue(false),
     } as unknown as jest.Mocked<First2FinishService>;
 
     scheduler = new SchedulerService(
@@ -614,6 +616,26 @@ describe('SchedulerService (review phase deferral)', () => {
     });
 
     challengeApiService.getPhaseDetails.mockResolvedValue(phaseDetails);
+    challengeApiService.getChallengeById.mockResolvedValue({
+      id: payload.challengeId,
+      phases: [phaseDetails],
+      reviewers: [
+        {
+          id: 'checkpoint-reviewer-config',
+          scorecardId: 'checkpoint-scorecard',
+          isMemberReview: true,
+          memberReviewerCount: 1,
+          phaseId: payload.phaseId,
+          fixedAmount: null,
+          baseCoefficient: null,
+          incrementalCoefficient: null,
+          type: null,
+          aiWorkflowId: null,
+          shouldOpenOpportunity: false,
+        },
+      ],
+      legacy: {},
+    } as unknown as IChallenge);
     reviewService.getPendingReviewCount.mockResolvedValue(0);
 
     const advancePhaseResponse: Awaited<

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -369,10 +369,6 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       };
 
       await this.triggerKafkaEvent(effectiveData);
-
-      // Call advancePhase method when phase transition is triggered
-      // Use the normalized operator so scheduler-specific rules apply
-      await this.advancePhase(effectiveData);
     } catch (error) {
       this.logger.error(
         `Failed to trigger Kafka event for job ${jobId}`,

--- a/src/challenge/challenge-api.service.spec.ts
+++ b/src/challenge/challenge-api.service.spec.ts
@@ -22,7 +22,7 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
   let challengeUpdate: jest.Mock;
   let challengeFindUnique: jest.Mock;
   let txChallengeFindUnique: jest.Mock;
-  let txPhaseFindUnique: jest.Mock;
+  let txPhaseFindFirst: jest.Mock;
   let txQueryRaw: jest.Mock;
   let service: ChallengeApiService;
   let configService: jest.Mocked<ConfigService>;
@@ -33,13 +33,13 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
     challengePhaseUpdate = jest.fn().mockResolvedValue(undefined);
     challengePhaseCreate = jest.fn().mockResolvedValue({ id: 'new-phase' });
     challengePhaseDeleteMany = jest.fn().mockResolvedValue({ count: 0 });
-    challengePhaseUpdateMany = jest.fn().mockResolvedValue({ count: 0 });
+    challengePhaseUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
     challengePhaseFindMany = jest.fn().mockResolvedValue([]);
     challengeUpdate = jest.fn().mockResolvedValue(undefined);
 
     challengeFindUnique = jest.fn();
     txChallengeFindUnique = jest.fn();
-    txPhaseFindUnique = jest.fn();
+    txPhaseFindFirst = jest.fn();
     txQueryRaw = jest.fn().mockResolvedValue(undefined);
 
     prisma = {
@@ -64,7 +64,7 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
           update: challengeUpdate,
         },
         phase: {
-          findUnique: txPhaseFindUnique,
+          findFirst: txPhaseFindFirst,
         },
         challengePhase: {
           update: challengePhaseUpdate,
@@ -182,16 +182,22 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
 
     expect(challengeFindUnique).toHaveBeenCalled();
     expect(rescheduleSpy).toHaveBeenCalledWith('challenge-1', reviewPhase.id);
-    expect(challengePhaseUpdate).toHaveBeenCalledWith({
-      where: { id: reviewPhase.id },
-      data: expect.objectContaining({
-        scheduledStartDate: fixedNow,
-        scheduledEndDate: new Date(
-          fixedNow.getTime() + phaseDurationSeconds * 1000,
-        ),
-        duration: phaseDurationSeconds,
+    expect(challengePhaseUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: reviewPhase.id,
+          isOpen: false,
+        }),
+        data: expect.objectContaining({
+          isOpen: true,
+          scheduledStartDate: fixedNow,
+          scheduledEndDate: new Date(
+            fixedNow.getTime() + phaseDurationSeconds * 1000,
+          ),
+          duration: phaseDurationSeconds,
+        }),
       }),
-    });
+    );
   });
 
   it('extends the appeals phase duration when opening late', async () => {
@@ -265,14 +271,20 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
 
     await service.advancePhase('challenge-appeals', 'appeals-phase', 'open');
 
-    expect(challengePhaseUpdate).toHaveBeenCalledWith({
-      where: { id: appealsPhase.id },
-      data: expect.objectContaining({
-        scheduledStartDate: lateNow,
-        scheduledEndDate: new Date(lateNow.getTime() + 3600 * 1000),
-        duration: appealsPhase.duration,
+    expect(challengePhaseUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: appealsPhase.id,
+          isOpen: false,
+        }),
+        data: expect.objectContaining({
+          isOpen: true,
+          scheduledStartDate: lateNow,
+          scheduledEndDate: new Date(lateNow.getTime() + 3600 * 1000),
+          duration: appealsPhase.duration,
+        }),
       }),
-    });
+    );
   });
 
   it('extends a non-appeals phase opened late when remaining time is shorter than the configured duration', async () => {
@@ -350,16 +362,22 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
       'open',
     );
 
-    expect(challengePhaseUpdate).toHaveBeenCalledWith({
-      where: { id: submissionPhase.id },
-      data: expect.objectContaining({
-        scheduledStartDate: lateNow,
-        scheduledEndDate: new Date(
-          lateNow.getTime() + submissionPhase.duration * 1000,
-        ),
-        duration: submissionPhase.duration,
+    expect(challengePhaseUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: submissionPhase.id,
+          isOpen: false,
+        }),
+        data: expect.objectContaining({
+          isOpen: true,
+          scheduledStartDate: lateNow,
+          scheduledEndDate: new Date(
+            lateNow.getTime() + submissionPhase.duration * 1000,
+          ),
+          duration: submissionPhase.duration,
+        }),
       }),
-    });
+    );
   });
 
   describe('createPostMortemPhase', () => {
@@ -465,7 +483,7 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
       );
       expect(reopenArgs.duration).toBe(72 * 60 * 60);
       expect(challengePhaseCreate).not.toHaveBeenCalled();
-      expect(txPhaseFindUnique).not.toHaveBeenCalled();
+      expect(txPhaseFindFirst).not.toHaveBeenCalled();
       expect(challengeUpdate).toHaveBeenCalledWith({
         where: { id: challengeId },
         data: { currentPhaseNames: [existingPostMortem.name] },
@@ -507,7 +525,7 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
         phases: [submissionPhase, iterativeReviewPhase],
         currentPhaseNames: [],
       } as any);
-      txPhaseFindUnique.mockResolvedValueOnce(postMortemPhaseType as any);
+      txPhaseFindFirst.mockResolvedValueOnce(postMortemPhaseType as any);
 
       const createdPostMortem = {
         id: 'phase-postmortem',
@@ -546,8 +564,8 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
       expect(challengePhaseDeleteMany).toHaveBeenCalledWith({
         where: { id: { in: [iterativeReviewPhase.id] } },
       });
-      expect(txPhaseFindUnique).toHaveBeenCalledWith({
-        where: { name: 'Post-Mortem' },
+      expect(txPhaseFindFirst).toHaveBeenCalledWith({
+        where: { name: { in: expect.arrayContaining(['Post-Mortem']) } },
       });
       expect(challengePhaseCreate).toHaveBeenCalledWith({
         data: expect.objectContaining({
@@ -626,7 +644,7 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
         name: 'Post-Mortem',
         description: 'Post-Mortem phase',
       };
-      txPhaseFindUnique.mockResolvedValueOnce(postMortemPhaseType as any);
+      txPhaseFindFirst.mockResolvedValueOnce(postMortemPhaseType as any);
 
       const createdPostMortem = {
         id: 'phase-postmortem',
@@ -712,7 +730,7 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
         name: 'Post-Mortem',
         description: 'Post-Mortem phase',
       };
-      txPhaseFindUnique.mockResolvedValueOnce(postMortemPhaseType as any);
+      txPhaseFindFirst.mockResolvedValueOnce(postMortemPhaseType as any);
 
       const createdPostMortem = { id: 'phase-postmortem' };
       challengePhaseCreate.mockResolvedValueOnce(createdPostMortem as any);

--- a/src/sync/sync.service.spec.ts
+++ b/src/sync/sync.service.spec.ts
@@ -14,6 +14,7 @@ describe('SyncService', () => {
   };
   let schedulerService: {
     getAllScheduledTransitionsWithData: jest.Mock;
+    buildJobId: jest.Mock;
   };
 
   beforeEach(() => {
@@ -30,6 +31,11 @@ describe('SyncService', () => {
 
     schedulerService = {
       getAllScheduledTransitionsWithData: jest.fn().mockReturnValue(new Map()),
+      buildJobId: jest
+        .fn()
+        .mockImplementation((challengeId: string, phaseId: string) => {
+          return `${challengeId}|${phaseId}`;
+        }),
     };
 
     service = new SyncService(
@@ -157,5 +163,67 @@ describe('SyncService', () => {
       status: 'CANCELLED_FAILED_REVIEW',
       operator: AutopilotOperator.SYSTEM_SYNC,
     });
+  });
+
+  it('matches scheduled jobs by BullMQ job ID and cancels obsolete job IDs safely', async () => {
+    const challengeId = 'challenge-active';
+    const phaseId = 'phase-active';
+    const activeJobId = `${challengeId}|${phaseId}`;
+    const obsoleteJobId = 'challenge-obsolete|phase-obsolete';
+    const scheduledEndDate = '2026-03-31T09:42:04.567Z';
+
+    schedulerService.getAllScheduledTransitionsWithData.mockReturnValue(
+      new Map([
+        [
+          activeJobId,
+          {
+            date: scheduledEndDate,
+            state: 'END',
+          },
+        ],
+        [
+          obsoleteJobId,
+          {
+            date: '2026-03-30T09:42:04.567Z',
+            state: 'END',
+          },
+        ],
+      ]),
+    );
+
+    challengeApiService.getAllActiveChallenges.mockImplementation(
+      ({ status }: { status?: string }) => {
+        if (status === 'ACTIVE') {
+          return [
+            {
+              id: challengeId,
+              projectId: 999,
+              status: 'ACTIVE',
+              phases: [
+                {
+                  id: phaseId,
+                  name: 'Review',
+                  isOpen: true,
+                  actualEndDate: null,
+                  scheduledEndDate,
+                },
+              ],
+            },
+          ];
+        }
+
+        return [];
+      },
+    );
+
+    await service.synchronizeChallenges();
+
+    expect(autopilotService.schedulePhaseTransition).not.toHaveBeenCalled();
+    expect(autopilotService.reschedulePhaseTransition).not.toHaveBeenCalled();
+    expect(autopilotService.cancelPhaseTransition).toHaveBeenCalledTimes(1);
+    expect(autopilotService.cancelPhaseTransition).toHaveBeenCalledWith(
+      'challenge-obsolete',
+      'phase-obsolete',
+    );
   });
 });

--- a/src/sync/sync.service.ts
+++ b/src/sync/sync.service.ts
@@ -47,9 +47,9 @@ export class SyncService {
 
       const scheduledJobs =
         this.schedulerService.getAllScheduledTransitionsWithData();
-      const scheduledPhaseKeys = new Set(scheduledJobs.keys());
+      const scheduledJobIds = new Set(scheduledJobs.keys());
 
-      const activePhaseKeys = new Set<string>();
+      const activeJobIds = new Set<string>();
       const now = new Date();
 
       // 1. Add/update schedules for active challenges
@@ -103,9 +103,10 @@ export class SyncService {
           if (!scheduleDate) continue;
 
           const phaseKey = `${challenge.id}:${phase.id}`;
-          activePhaseKeys.add(phaseKey);
+          const jobId = this.schedulerService.buildJobId(challenge.id, phase.id);
+          activeJobIds.add(jobId);
 
-          const scheduledJob = scheduledJobs.get(phaseKey);
+          const scheduledJob = scheduledJobs.get(jobId);
 
           const phaseData: PhaseTransitionPayload = {
             projectId: challenge.projectId,
@@ -143,15 +144,23 @@ export class SyncService {
       }
 
       // 2. Remove obsolete schedules
-      for (const scheduledPhaseKey of scheduledPhaseKeys) {
-        if (!activePhaseKeys.has(scheduledPhaseKey)) {
+      for (const scheduledJobId of scheduledJobIds) {
+        if (!activeJobIds.has(scheduledJobId)) {
           this.logger.log(
-            `Obsolete schedule found: ${scheduledPhaseKey}. Cancelling...`,
+            `Obsolete schedule found: ${scheduledJobId}. Cancelling...`,
           );
-          const [challengeId, phaseId] = scheduledPhaseKey.split(':');
+
+          const parsedJob = this.parseScheduledJobId(scheduledJobId);
+          if (!parsedJob) {
+            this.logger.warn(
+              `Unable to parse scheduled job ID ${scheduledJobId}; skipping cancellation.`,
+            );
+            continue;
+          }
+
           await this.autopilotService.cancelPhaseTransition(
-            challengeId,
-            phaseId,
+            parsedJob.challengeId,
+            parsedJob.phaseId,
           );
           removed++;
         }
@@ -167,6 +176,31 @@ export class SyncService {
       const err = error as Error;
       this.logger.error('Challenge synchronization failed', err.stack);
     }
+  }
+
+  private parseScheduledJobId(
+    jobId: string,
+  ): { challengeId: string; phaseId: string } | null {
+    if (!jobId) {
+      return null;
+    }
+
+    const delimiter = jobId.includes('|')
+      ? '|'
+      : jobId.includes(':')
+        ? ':'
+        : null;
+
+    if (!delimiter) {
+      return null;
+    }
+
+    const [challengeId, phaseId] = jobId.split(delimiter);
+    if (!challengeId || !phaseId) {
+      return null;
+    }
+
+    return { challengeId, phaseId };
   }
 
   /**


### PR DESCRIPTION
> #### The biggest problem is a key-format mismatch in sync.
> 
> - In autopilot-v6/src/autopilot/services/scheduler.service.ts, scheduled job IDs are stored as `challengeId|phaseId`.
> - But autopilot-v6/src/sync/sync.service.ts reads those raw keys, then later looks schedules up using `challengeId:phaseId` and removes them by splitting on `:` in autopilot-v6/src/sync/sync.service.ts and autopilot-v6/src/sync/sync.service.ts.
> 
> That explains these log patterns:
> - repeated “New active phase found … Scheduling …” for the same phase every 3 minutes
> - immediate “Obsolete schedule found …”
> - `No active schedule found for challenge ...|..., phase undefined`
> 
> So that part is a real bug.
> 
> #### Second issue: the same scheduled transition is being executed twice.
> 
> - autopilot-v6/src/autopilot/services/scheduler.service.ts does both:
>   - `triggerKafkaEvent(...)`
>   - `advancePhase(...)`
> 
> If the Kafka consumer also processes that same event and advances the phase, you get exactly what the logs show:
> - event consumed
> - `Advancing phase ...`
> - same phase advanced again
> - one succeeds, the other errors with “already closed”
> 
> That also lines up with the BullMQ removal race:
> - `Job ... could not be removed because it is locked by another worker`
> 
> #### Third issue: open review phases are reprocessed on every challenge update.
> 
> - autopilot-v6/src/autopilot/services/phase-schedule-manager.service.ts scans already-open review/screening/approval phases and calls `handlePhaseOpenedForChallenge()` again.
> 
> That matches:
> - review phase opens and creates 1 pending review
> - later manual phase detection processes the same open review phase
> - then it creates 2 more pending reviews
> 
> That may be intentional as backfill, but it is definitely another re-entry path.
> 
> #### Fourth issue: review opportunity creation is noisy and likely non-idempotent.
> 
> - autopilot-v6/src/autopilot/services/phase-schedule-manager.service.ts calls review opportunity creation on every ACTIVE challenge update.
> - The create flow is list-then-create in autopilot-v6/src/autopilot/services/phase-schedule-manager.service.ts.
> 
> That makes 409 conflicts unsurprising under races or stale reads. It should probably treat HTTP 409 as “already exists” instead of an error.
> 
> So: yes, there are real issues here, not just noisy logs.


**Fixes implemented:**
- Fixed sync key mismatch in sync.service.ts:
  - Uses scheduler job IDs (`challenge|phase`) for map lookups/comparisons.
  - Adds robust job-id parsing for cleanup, with safe skip + warning on malformed IDs.
  - Removes the `phase undefined` cancellation pattern caused by `:` splitting.
- Removed duplicate execution path in scheduler.service.ts:
  - `runScheduledTransition()` now emits the Kafka transition event and no longer also calls local `advancePhase()`.
  - Prevents “same END processed twice / already closed” behavior from scheduler path.
- Added manual open-phase dedupe in phase-schedule-manager.service.ts:
  - Tracks per challenge+phase fingerprint for open-phase processing.
  - Skips reprocessing unchanged open review/screening/approval phases on repeated challenge updates.
  - Prunes stale phase entries when phases are no longer open.

**Tests**
- Added regression test in sync.service.spec.ts for pipe-delimited job IDs + obsolete cancellation parsing.
- Added regression test in phase-schedule-manager.service.spec.ts to ensure unchanged open phases are processed once.
- Verified: targeted suites pass (`2/2`).
- Note: the broad scheduler suite is currently noisy/flaky in this env (Redis/connect + timeout), but this was outside the targeted change verification.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topcoder-platform/autopilot-v6/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
