### PR TITLE
PM-4691: infer iterative opportunity type from F2F review phase

### DIFF
--- a/src/autopilot/services/phase-schedule-manager.service.spec.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.spec.ts
@@ -1,10 +1,26 @@
+import type { ConfigService } from '@nestjs/config';
+import type { ChallengeApiService } from '../../challenge/challenge-api.service';
+import type { FinanceApiService } from '../../finance/finance-api.service';
 import { AutopilotOperator } from '../interfaces/autopilot.interface';
+import type { ReviewApiService } from '../../review/review-api.service';
+import type { ReviewService } from '../../review/review.service';
+import type { SchedulerService } from './scheduler.service';
+import type { PhaseReviewService } from './phase-review.service';
+import type { ReviewAssignmentService } from './review-assignment.service';
+import type { AutopilotDbLoggerService } from './autopilot-db-logger.service';
 import { PhaseScheduleManager } from './phase-schedule-manager.service';
 
 describe('PhaseScheduleManager', () => {
   let service: PhaseScheduleManager;
   let challengeApiService: {
     getChallengeById: jest.Mock;
+  };
+  let reviewApiService: {
+    createReviewOpportunity: jest.Mock;
+    getReviewOpportunitiesByChallengeId: jest.Mock;
+  };
+  let dbLogger: {
+    logAction: jest.Mock;
   };
   let financeApiService: {
     generateChallengePayments: jest.Mock;
@@ -15,6 +31,15 @@ describe('PhaseScheduleManager', () => {
       getChallengeById: jest.fn(),
     };
 
+    reviewApiService = {
+      createReviewOpportunity: jest.fn().mockResolvedValue({ id: 'opp-1' }),
+      getReviewOpportunitiesByChallengeId: jest.fn().mockResolvedValue([]),
+    };
+
+    dbLogger = {
+      logAction: jest.fn().mockResolvedValue(undefined),
+    };
+
     financeApiService = {
       generateChallengePayments: jest.fn().mockResolvedValue(true),
     };
@@ -22,19 +47,17 @@ describe('PhaseScheduleManager', () => {
     service = new PhaseScheduleManager(
       {
         setPhaseChainCallback: jest.fn(),
-      } as any,
-      challengeApiService as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      {} as any,
+      } as unknown as SchedulerService,
+      challengeApiService as unknown as ChallengeApiService,
+      {} as unknown as PhaseReviewService,
+      {} as unknown as ReviewAssignmentService,
+      {} as unknown as ReviewService,
+      reviewApiService as unknown as ReviewApiService,
       {
         get: jest.fn().mockReturnValue(undefined),
-      } as any,
-      {
-        logAction: jest.fn(),
-      } as any,
-      financeApiService as any,
+      } as unknown as ConfigService,
+      dbLogger as unknown as AutopilotDbLoggerService,
+      financeApiService as unknown as FinanceApiService,
     );
   });
 
@@ -123,6 +146,50 @@ describe('PhaseScheduleManager', () => {
     );
     expect(financeApiService.generateChallengePayments).toHaveBeenCalledWith(
       'challenge-3',
+    );
+  });
+
+  it('infers iterative review opportunities from the reviewer phase when reviewer type is missing', async () => {
+    await (
+      service as unknown as {
+        createReviewOpportunitiesForChallenge: (
+          challenge: unknown,
+        ) => Promise<void>;
+      }
+    ).createReviewOpportunitiesForChallenge({
+      id: 'challenge-iterative',
+      status: 'ACTIVE',
+      phases: [
+        {
+          id: 'phase-1',
+          phaseId: 'iterative-review-phase',
+          name: 'Iterative Review',
+          duration: 86400,
+          scheduledStartDate: '2026-04-02T00:00:00.000Z',
+          actualStartDate: null,
+        },
+      ],
+      prizeSets: [],
+      reviewers: [
+        {
+          id: 'reviewer-1',
+          isMemberReview: true,
+          memberReviewerCount: 1,
+          phaseId: 'iterative-review-phase',
+          fixedAmount: 25,
+          baseCoefficient: null,
+          incrementalCoefficient: null,
+          type: null,
+          shouldOpenOpportunity: true,
+        },
+      ],
+    });
+
+    expect(reviewApiService.createReviewOpportunity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        challengeId: 'challenge-iterative',
+        type: 'ITERATIVE_REVIEW',
+      }),
     );
   });
 });

--- a/src/autopilot/services/phase-schedule-manager.service.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.ts
@@ -21,6 +21,7 @@ import {
   CHECKPOINT_SUBMISSION_PHASE_NAME,
   DEFAULT_APPEALS_PHASE_NAMES,
   DEFAULT_APPEALS_RESPONSE_PHASE_NAMES,
+  ITERATIVE_REVIEW_PHASE_NAME,
   REGISTRATION_PHASE_NAME,
   REVIEW_PHASE_NAMES,
   SCREENING_PHASE_NAMES,
@@ -594,20 +595,19 @@ export class PhaseScheduleManager {
     let createdCount = 0;
 
     for (const reviewer of reviewers) {
-      const type =
-        reviewer.type?.toString().trim().toUpperCase() || 'REGULAR_REVIEW';
+      const phase = this.findPhaseForReviewer(challenge, reviewer);
+      const type = this.resolveReviewOpportunityType(reviewer, phase);
 
-      if (existingTypes.has(type)) {
-        this.logger.log(
-          `[REVIEW OPPORTUNITIES] Opportunity of type ${type} already exists for challenge ${challenge.id}; skipping duplicate creation.`,
+      if (!phase) {
+        this.logger.warn(
+          `[REVIEW OPPORTUNITIES] Unable to locate phase for reviewer ${reviewer.id} on challenge ${challenge.id}; skipping opportunity creation for type ${type}.`,
         );
         continue;
       }
 
-      const phase = this.findPhaseForReviewer(challenge, reviewer);
-      if (!phase) {
-        this.logger.warn(
-          `[REVIEW OPPORTUNITIES] Unable to locate phase for reviewer ${reviewer.id} on challenge ${challenge.id}; skipping opportunity creation for type ${type}.`,
+      if (existingTypes.has(type)) {
+        this.logger.log(
+          `[REVIEW OPPORTUNITIES] Opportunity of type ${type} already exists for challenge ${challenge.id}; skipping duplicate creation.`,
         );
         continue;
       }
@@ -689,6 +689,35 @@ export class PhaseScheduleManager {
     return (challenge.phases ?? []).find(
       (phase) => phase.phaseId === reviewer.phaseId,
     );
+  }
+
+  /**
+   * Resolve the review opportunity type for a reviewer configuration.
+   * Falls back to the linked phase so legacy/manual F2F reviewer configs
+   * without an explicit type still open iterative review opportunities.
+   *
+   * @param reviewer reviewer configuration from challenge-api
+   * @param phase matched challenge phase for the reviewer, if any
+   * @returns normalized review opportunity type for review-api
+   */
+  private resolveReviewOpportunityType(
+    reviewer: IChallengeReviewer,
+    phase?: IPhase,
+  ): string {
+    const explicitType = reviewer.type?.toString().trim().toUpperCase();
+
+    if (explicitType) {
+      return explicitType;
+    }
+
+    if (
+      phase?.name?.toString().trim().toUpperCase() ===
+      ITERATIVE_REVIEW_PHASE_NAME.toUpperCase()
+    ) {
+      return 'ITERATIVE_REVIEW';
+    }
+
+    return 'REGULAR_REVIEW';
   }
 
   private resolvePhaseDuration(phase: IPhase): number {


### PR DESCRIPTION
What was broken
Public review openings created from First2Finish iterative reviewer configs could be opened as regular review opportunities. Approved applicants were then added to the challenge as Reviewer instead of Iterative Reviewer, so the review app did not surface iterative review submissions for them.

Root cause
Autopilot treated a missing reviewer opportunity type as REGULAR_REVIEW. Manual and legacy F2F reviewer configs can omit that field even when tied to the Iterative Review phase.

What was changed
Autopilot now resolves the review opportunity type from the linked reviewer phase before falling back to REGULAR_REVIEW.
Reviewer configs attached to the Iterative Review phase now create ITERATIVE_REVIEW opportunities even when the explicit type is missing.

Any added/updated tests
Added a PhaseScheduleManager regression test that covers an Iterative Review phase reviewer with no explicit type and asserts that the created opportunity type is ITERATIVE_REVIEW.
