### PR TITLE
PM-5015 - ai only review mode

### DIFF
--- a/src/autopilot/constants/review.constants.ts
+++ b/src/autopilot/constants/review.constants.ts
@@ -1,5 +1,6 @@
 export const ITERATIVE_REVIEW_PHASE_NAME = 'Iterative Review';
 export const AI_SCREENING_PHASE_NAME = 'AI Screening';
+export const AI_REVIEW_PHASE_NAME = 'AI Review';
 export const POST_MORTEM_PHASE_NAME = 'Post-Mortem';
 export const POST_MORTEM_PHASE_ALTERNATE_NAME = 'Post-mortem';
 export const POST_MORTEM_PHASE_NAMES = new Set<string>([

--- a/src/autopilot/services/autopilot.service.ts
+++ b/src/autopilot/services/autopilot.service.ts
@@ -33,6 +33,7 @@ import {
   SCREENING_PHASE_NAMES,
   APPROVAL_PHASE_NAMES,
   PHASE_ROLE_MAP,
+  AI_REVIEW_PHASE_NAME,
   AI_SCREENING_PHASE_NAME,
 } from '../constants/review.constants';
 import { ReviewService } from '../../review/review.service';
@@ -790,17 +791,22 @@ export class AutopilotService {
       const aiScreeningPhase = challenge.phases.find(
         (p) => p.name === AI_SCREENING_PHASE_NAME,
       );
+      // For AI_ONLY challenges there is no AI Screening phase — the AI Review phase
+      // serves the equivalent role and should be closed when all workflows complete.
+      const aiActivePhase =
+        aiScreeningPhase ??
+        challenge.phases.find((p) => p.name === AI_REVIEW_PHASE_NAME);
 
-      if (!aiScreeningPhase) {
+      if (!aiActivePhase) {
         this.logger.debug(
-          `No AI Screening phase found for challenge ${challengeId}; ignoring AI workflow completion`,
+          `No AI Screening or AI Review phase found for challenge ${challengeId}; ignoring AI workflow completion`,
         );
         return;
       }
 
-      if (!aiScreeningPhase.isOpen) {
+      if (!aiActivePhase.isOpen) {
         this.logger.debug(
-          `AI Screening phase ${aiScreeningPhase.id} already closed for challenge ${challengeId}; ignoring AI workflow completion event`,
+          `AI phase ${aiActivePhase.id} (${aiActivePhase.name}) already closed for challenge ${challengeId}; ignoring AI workflow completion event`,
         );
         return;
       }
@@ -839,25 +845,25 @@ export class AutopilotService {
 
         if (inProgressAiWorkflows > 0) {
           this.logger.debug(
-            `AI Screening phase ${aiScreeningPhase.id} for challenge ${challengeId} still has ${inProgressAiWorkflows} in-progress AI workflow(s). Not closing phase.`,
+            `AI phase ${aiActivePhase.id} (${aiActivePhase.name}) for challenge ${challengeId} still has ${inProgressAiWorkflows} in-progress AI workflow(s). Not closing phase.`,
           );
           return;
         }
 
         this.logger.log(
-          `All AI workflows completed for phase ${aiScreeningPhase.id} on challenge ${challengeId}. Closing AI Screening phase early.`,
+          `All AI workflows completed for phase ${aiActivePhase.id} (${aiActivePhase.name}) on challenge ${challengeId}. Closing phase early.`,
         );
       } else {
         this.logger.log(
-          `AI workflow completed for F2F challenge ${challengeId}, submission ${payload.submissionId}. Closing AI Screening phase.`,
+          `AI workflow completed for F2F challenge ${challengeId}, submission ${payload.submissionId}. Closing ${aiActivePhase.name} phase.`,
         );
       }
 
       await this.schedulerService.advancePhase({
         projectId: challenge.projectId,
         challengeId: challenge.id,
-        phaseId: aiScreeningPhase.id,
-        phaseTypeName: aiScreeningPhase.name,
+        phaseId: aiActivePhase.id,
+        phaseTypeName: aiActivePhase.name,
         state: 'END',
         operator: AutopilotOperator.SYSTEM,
         projectStatus: challenge.status,

--- a/src/autopilot/services/challenge-completion.service.ts
+++ b/src/autopilot/services/challenge-completion.service.ts
@@ -12,7 +12,7 @@ import {
 import { ChallengeStatusEnum, PrizeSetTypeEnum } from '@prisma/client';
 import { FinanceApiService } from '../../finance/finance-api.service';
 import { ReviewSummationApiService } from './review-summation-api.service';
-import { POST_MORTEM_REVIEWER_ROLE_NAME } from '../constants/review.constants';
+import { POST_MORTEM_REVIEWER_ROLE_NAME, AI_REVIEW_PHASE_NAME } from '../constants/review.constants';
 import { KafkaService } from '../../kafka/kafka.service';
 import { KAFKA_TOPICS } from '../../kafka/constants/topics';
 import { AutopilotOperator } from '../interfaces/autopilot.interface';
@@ -554,6 +554,13 @@ export class ChallengeCompletionService {
     await this.reviewSummationApiService.finalizeSummations(challengeId);
 
     const isMarathonMatch = isMarathonMatchChallenge(challenge.type);
+    const isAiOnly = (challenge.phases ?? []).some(
+      (p) => p.name === AI_REVIEW_PHASE_NAME,
+    );
+
+    if (isAiOnly) {
+      return this.finalizeAiOnlyChallenge(challengeId, challenge);
+    }
 
     if (isMarathonMatch) {
       const marathonMatchConfig =
@@ -695,6 +702,129 @@ export class ChallengeCompletionService {
     );
     this.logger.log(
       `Marked challenge ${challengeId} as COMPLETED with ${placementWinners.length} winner(s) and ${passedReviewWinners.length} passed review record(s).`,
+    );
+    return true;
+  }
+
+  /**
+   * Finalizes an AI_ONLY challenge using AI decision scores instead of human
+   * review summations.  Ranking is by `totalScore` descending; ties break on
+   * submission timestamp (earlier wins), then submission id lexicographically.
+   * Only submissions whose latest AI decision is PASSED or HUMAN_OVERRIDE are
+   * eligible to win a placement prize.
+   */
+  private async finalizeAiOnlyChallenge(
+    challengeId: string,
+    challenge: IChallenge,
+  ): Promise<boolean> {
+    const summaries =
+      await this.reviewService.getAiDecisionSummaries(challengeId);
+
+    if (!summaries.length) {
+      if ((challenge.numOfSubmissions ?? 0) === 0) {
+        this.logger.log(
+          `AI_ONLY challenge ${challengeId} has no submissions; marking as CANCELLED_ZERO_SUBMISSIONS.`,
+        );
+        await this.challengeApiService.cancelChallenge(
+          challengeId,
+          ChallengeStatusEnum.CANCELLED_ZERO_SUBMISSIONS,
+        );
+        await this.ensureCancelledPostMortem(challengeId);
+        return true;
+      }
+
+      this.logger.warn(
+        `AI decision data not yet available for challenge ${challengeId}; will retry finalization later.`,
+      );
+      return false;
+    }
+
+    const passingSummaries = summaries.filter((s) => s.isPassing);
+
+    if (!passingSummaries.length) {
+      this.logger.log(
+        `No passing AI decisions for challenge ${challengeId}; marking as CANCELLED_FAILED_REVIEW.`,
+      );
+      await this.challengeApiService.cancelChallenge(
+        challengeId,
+        ChallengeStatusEnum.CANCELLED_FAILED_REVIEW,
+      );
+      await this.ensureCancelledPostMortem(challengeId);
+      void this.financeApiService.generateChallengePayments(challengeId);
+      return true;
+    }
+
+    const sortedSummaries = [...passingSummaries].sort((a, b) => {
+      if (b.aggregateScore !== a.aggregateScore) {
+        return b.aggregateScore - a.aggregateScore;
+      }
+      const timeDiff =
+        this.getSubmissionTimestamp(a.submittedDate) -
+        this.getSubmissionTimestamp(b.submittedDate);
+      if (timeDiff !== 0) {
+        return timeDiff;
+      }
+      return a.submissionId.localeCompare(b.submissionId);
+    });
+
+    const memberIds = Array.from(
+      new Set(
+        sortedSummaries
+          .map((s) => s.memberId?.trim())
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    const handleMap = await this.resourcesService.getMemberHandleMap(
+      challengeId,
+      memberIds,
+    );
+
+    const placementPrizeLimit = this.countPlacementPrizes(
+      challenge.prizeSets ?? [],
+    );
+    const placementWinnerLimit =
+      placementPrizeLimit > 0 ? placementPrizeLimit : sortedSummaries.length;
+    const placementSummaries = sortedSummaries.slice(0, placementWinnerLimit);
+    const passedReviewSummaries = sortedSummaries.slice(placementWinnerLimit);
+
+    const placementWinners = placementSummaries
+      .map((summary, index) =>
+        this.buildWinnerRecord(
+          challengeId,
+          summary,
+          handleMap,
+          index + 1,
+          PrizeSetTypeEnum.PLACEMENT,
+        ),
+      )
+      .filter((winner): winner is IChallengeWinner => winner !== null);
+
+    const passedReviewWinners = passedReviewSummaries
+      .map((summary, index) =>
+        this.buildWinnerRecord(
+          challengeId,
+          summary,
+          handleMap,
+          index + 1,
+          PrizeSetTypeEnum.PASSED_REVIEW,
+        ),
+      )
+      .filter((winner): winner is IChallengeWinner => winner !== null);
+
+    const winners = [...placementWinners, ...passedReviewWinners];
+
+    await this.challengeApiService.completeChallenge(challengeId, winners);
+    await this.syncChallengeResults(challengeId, challenge, placementWinners);
+    void this.financeApiService.generateChallengePayments(challengeId);
+    void this.triggerStatsRefreshForWinners(challengeId, placementWinners);
+    await this.publishChallengeCompletionUpdate(
+      challengeId,
+      placementWinners,
+      challenge,
+    );
+    this.logger.log(
+      `[AI_ONLY] Marked challenge ${challengeId} as COMPLETED with ${placementWinners.length} winner(s) and ${passedReviewWinners.length} passed review record(s) based on AI decision scores.`,
     );
     return true;
   }

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -23,6 +23,7 @@ import { Job, Queue, RedisOptions, Worker } from 'bullmq';
 import { ChallengeStatusEnum } from '@prisma/client';
 import { ReviewService } from '../../review/review.service';
 import {
+  AI_REVIEW_PHASE_NAME,
   AI_SCREENING_PHASE_NAME,
   POST_MORTEM_REVIEWER_ROLE_NAME,
   REGISTRATION_PHASE_NAME,
@@ -513,6 +514,9 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       const isAiScreeningPhase =
         phaseName === AI_SCREENING_PHASE_NAME ||
         data.phaseTypeName === AI_SCREENING_PHASE_NAME;
+      const isAiReviewPhase =
+        phaseName === AI_REVIEW_PHASE_NAME ||
+        data.phaseTypeName === AI_REVIEW_PHASE_NAME;
       const isApprovalPhase =
         APPROVAL_PHASE_NAMES.has(phaseName) ||
         APPROVAL_PHASE_NAMES.has(data.phaseTypeName);
@@ -794,6 +798,44 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
           const err = error as Error;
           this.logger.error(
             `[AI SCREENING LATE] Unable to verify AI workflow readiness for phase ${data.phaseId} on challenge ${data.challengeId}: ${err.message}`,
+            err.stack,
+          );
+
+          await this.deferAiScreeningPhaseClosure(
+            data,
+            undefined,
+            'unable to verify AI workflow readiness',
+          );
+          return;
+        }
+      }
+
+      // Block closing AI Review (AI_ONLY mode) until all configured AI workflows are completed
+      if (operation === 'close' && isAiReviewPhase) {
+        try {
+          const challenge = await this.challengeApiService.getChallengeById(
+            data.challengeId,
+          );
+          const aiWorkflowIds = this.getAiWorkflowIds(challenge);
+
+          const inProgressAiWorkflows =
+            await this.reviewService.getInProgressAiWorkflowRunCount(
+              data.challengeId,
+              aiWorkflowIds,
+            );
+
+          if (inProgressAiWorkflows > 0) {
+            await this.deferAiScreeningPhaseClosure(
+              data,
+              inProgressAiWorkflows,
+              `${inProgressAiWorkflows} in-progress AI workflow run(s) detected`,
+            );
+            return;
+          }
+        } catch (error) {
+          const err = error as Error;
+          this.logger.error(
+            `[AI REVIEW LATE] Unable to verify AI workflow readiness for phase ${data.phaseId} on challenge ${data.challengeId}: ${err.message}`,
             err.stack,
           );
 
@@ -1142,6 +1184,12 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
               err.stack,
             );
           }
+        }
+
+        if (operation === 'close' && isAiReviewPhase) {
+          this.aiScreeningCloseRetryAttempts.delete(
+            this.buildAiScreeningPhaseKey(data.challengeId, data.phaseId),
+          );
         }
 
         if (operation === 'close' && phaseName === REGISTRATION_PHASE_NAME) {

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -975,6 +975,101 @@ export class ReviewService {
     }
   }
 
+  /**
+   * Returns AI decision summaries for all active contest submissions in a challenge.
+   * Used by `ChallengeCompletionService` to finalize AI_ONLY challenges in place of
+   * human review summations.
+   *
+   * Picks the latest decision per submission (ordered by config version then decision
+   * timestamp), filters out PENDING entries, and marks a submission as passing when
+   * its decision status is PASSED or HUMAN_OVERRIDE.
+   */
+  async getAiDecisionSummaries(
+    challengeId: string,
+  ): Promise<SubmissionSummary[]> {
+    if (!challengeId) {
+      return [];
+    }
+
+    const query = Prisma.sql`
+      WITH ranked_decisions AS (
+        SELECT
+          d."submissionId",
+          d."totalScore",
+          UPPER((d."status")::text) AS "status",
+          ROW_NUMBER() OVER (
+            PARTITION BY d."submissionId"
+            ORDER BY
+              c."version" DESC,
+              COALESCE(d."finalizedAt", d."updatedAt", d."createdAt") DESC,
+              d."id" DESC
+          ) AS "rn"
+        FROM ${ReviewService.AI_REVIEW_DECISION_TABLE} d
+        INNER JOIN ${ReviewService.AI_REVIEW_CONFIG_TABLE} c
+          ON c."id" = d."configId"
+        WHERE c."challengeId" = ${challengeId}
+          AND UPPER((d."status")::text) != 'PENDING'
+      )
+      SELECT
+        s."id"                   AS "submissionId",
+        s."legacySubmissionId"   AS "legacySubmissionId",
+        s."memberId"             AS "memberId",
+        s."submittedDate"        AS "submittedDate",
+        COALESCE(rd."totalScore", 0) AS "totalScore",
+        rd."status"              AS "status"
+      FROM ${ReviewService.SUBMISSION_TABLE} s
+      INNER JOIN ranked_decisions rd ON rd."submissionId" = s."id"
+      WHERE s."challengeId" = ${challengeId}
+        AND rd."rn" = 1
+        AND (
+          s."type" IS NULL
+          OR UPPER((s."type")::text) = 'CONTEST_SUBMISSION'
+        )
+        AND UPPER(COALESCE((s."status")::text, '')) NOT IN ('DELETED', 'FAILED_SCREENING', 'AI_FAILED_REVIEW')
+    `;
+
+    try {
+      const rows = await this.prisma.$queryRaw<
+        {
+          submissionId: string;
+          legacySubmissionId: string | null;
+          memberId: string | null;
+          submittedDate: Date | null;
+          totalScore: string | number;
+          status: string;
+        }[]
+      >(query);
+
+      return rows.map((row) => {
+        const rawScore = Number(row.totalScore);
+        const aggregateScore = Number.isFinite(rawScore) ? rawScore : 0;
+        const isPassing =
+          row.status === 'PASSED' || row.status === 'HUMAN_OVERRIDE';
+
+        return {
+          submissionId: row.submissionId,
+          legacySubmissionId: row.legacySubmissionId ?? null,
+          memberId: row.memberId ?? null,
+          submittedDate: row.submittedDate ? new Date(row.submittedDate) : null,
+          aggregateScore,
+          scorecardId: null,
+          scorecardLegacyId: null,
+          passingScore: 0,
+          isPassing,
+        };
+      });
+    } catch (error) {
+      const err = error as Error;
+      void this.dbLogger.logAction('review.getAiDecisionSummaries', {
+        challengeId,
+        status: 'ERROR',
+        source: ReviewService.name,
+        details: { error: err.message },
+      });
+      throw err;
+    }
+  }
+
   async hasAiDecisionForSubmission(
     challengeId: string,
     submissionId: string,


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-5015

This pull request introduces support for finalizing "AI_ONLY" challenges, where AI decisions are used in place of human review summations to determine winners. The changes add the ability to recognize and process the new `AI Review` phase, ensuring that phase closure and challenge completion logic correctly handle this mode. Additionally, the pull request implements logic to rank and award winners based on AI decision scores and provides a new service method for retrieving AI decision summaries.

**Support for AI_ONLY challenge finalization:**

* Added the `AI_REVIEW_PHASE_NAME` constant and updated all relevant imports to recognize the new phase name. [[1]](diffhunk://#diff-be2ea74ef2fb8f35b25a9d9e2d8940e363ce4d1365f9ce6370592ac82550479fR3) [[2]](diffhunk://#diff-41ca205f1de3b96cab42276578c28d70af26c6dd326d09ec32bacf40678325a2R36) [[3]](diffhunk://#diff-68774c83708ba608097c7817613af4ea0889628b8154db7ec356341575a44e5aL15-R15) [[4]](diffhunk://#diff-f65844bce2a9c66523f2013866dec15ff1dbe7fd72f5d7f64e74c7f8b021eb5aR26)
* In `ChallengeCompletionService`, added detection for AI_ONLY challenges and implemented `finalizeAiOnlyChallenge`, which finalizes challenges based on AI decision scores, handles tie-breaking, and manages challenge cancellation when necessary. [[1]](diffhunk://#diff-68774c83708ba608097c7817613af4ea0889628b8154db7ec356341575a44e5aR557-R563) [[2]](diffhunk://#diff-68774c83708ba608097c7817613af4ea0889628b8154db7ec356341575a44e5aR709-R831)

**Phase closure and workflow handling:**

* Updated `AutopilotService` to treat the `AI Review` phase as equivalent to the `AI Screening` phase for AI_ONLY challenges, ensuring phase closure logic works for both. [[1]](diffhunk://#diff-41ca205f1de3b96cab42276578c28d70af26c6dd326d09ec32bacf40678325a2R794-R809) [[2]](diffhunk://#diff-41ca205f1de3b96cab42276578c28d70af26c6dd326d09ec32bacf40678325a2L842-R866)
* In `SchedulerService`, added logic to block closure of the `AI Review` phase until all configured AI workflows are complete, mirroring the screening phase's behavior. Also ensures retry attempts are managed for the new phase. [[1]](diffhunk://#diff-f65844bce2a9c66523f2013866dec15ff1dbe7fd72f5d7f64e74c7f8b021eb5aR517-R519) [[2]](diffhunk://#diff-f65844bce2a9c66523f2013866dec15ff1dbe7fd72f5d7f64e74c7f8b021eb5aR813-R850) [[3]](diffhunk://#diff-f65844bce2a9c66523f2013866dec15ff1dbe7fd72f5d7f64e74c7f8b021eb5aR1189-R1194)

**AI decision summary retrieval:**

* Added the `getAiDecisionSummaries` method to `ReviewService`, which retrieves and processes the latest AI decisions for all contest submissions, filtering and marking passing submissions appropriately for use in AI_ONLY challenge finalization.