### PR TITLE
PM-5203 approval phase ai only

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "prisma:generate": "prisma generate --schema prisma/challenge.schema.prisma && prisma generate --schema prisma/autopilot.schema.prisma",
     "postinstall": "prisma generate --schema prisma/challenge.schema.prisma && prisma generate --schema prisma/autopilot.schema.prisma && patch-package",
     "prisma:pushautopilot": "prisma db push --schema prisma/autopilot.schema.prisma",
-    "pull:logs": "ts-node scripts/fetch-autopilot-actions.ts"
+    "pull:logs": "ts-node scripts/fetch-autopilot-actions.ts",
+    "deploy:dev": "BRANCH=$(git rev-parse --abbrev-ref HEAD) && TAG=\"dev-${BRANCH}\" && git tag -d \"$TAG\" 2>/dev/null; git push origin \":refs/tags/$TAG\" 2>/dev/null; git tag \"$TAG\" && git push origin \"$TAG\""
   },
   "prisma": {
     "schema": "prisma/challenge.schema.prisma"

--- a/src/autopilot/services/challenge-completion.service.ts
+++ b/src/autopilot/services/challenge-completion.service.ts
@@ -12,7 +12,11 @@ import {
 import { ChallengeStatusEnum, PrizeSetTypeEnum } from '@prisma/client';
 import { FinanceApiService } from '../../finance/finance-api.service';
 import { ReviewSummationApiService } from './review-summation-api.service';
-import { POST_MORTEM_REVIEWER_ROLE_NAME, AI_REVIEW_PHASE_NAME } from '../constants/review.constants';
+import {
+  POST_MORTEM_REVIEWER_ROLE_NAME,
+  AI_REVIEW_PHASE_NAME,
+  APPROVAL_PHASE_NAMES,
+} from '../constants/review.constants';
 import { KafkaService } from '../../kafka/kafka.service';
 import { KAFKA_TOPICS } from '../../kafka/constants/topics';
 import { AutopilotOperator } from '../interfaces/autopilot.interface';
@@ -551,8 +555,6 @@ export class ChallengeCompletionService {
       return true;
     }
 
-    await this.reviewSummationApiService.finalizeSummations(challengeId);
-
     const isMarathonMatch = isMarathonMatchChallenge(challenge.type);
     const isAiOnly = (challenge.phases ?? []).some(
       (p) => p.name === AI_REVIEW_PHASE_NAME,
@@ -562,6 +564,7 @@ export class ChallengeCompletionService {
       return this.finalizeAiOnlyChallenge(challengeId, challenge);
     }
 
+    await this.reviewSummationApiService.finalizeSummations(challengeId);
     if (isMarathonMatch) {
       const marathonMatchConfig =
         await this.marathonMatchApiService.getConfig(challengeId);
@@ -717,6 +720,23 @@ export class ChallengeCompletionService {
     challengeId: string,
     challenge: IChallenge,
   ): Promise<boolean> {
+    // If the challenge has an Approval phase that hasn't closed yet, defer
+    // finalization.  Winners must only be determined after the Approval phase
+    // closes so that any manager score overrides applied during the approval
+    // window are reflected in the final rankings.
+    const approvalPhase = (challenge.phases ?? []).find((p) =>
+      APPROVAL_PHASE_NAMES.has(p.name ?? ''),
+    );
+    if (
+      approvalPhase &&
+      (approvalPhase.isOpen || !approvalPhase.actualEndDate)
+    ) {
+      this.logger.log(
+        `[AI_ONLY] Challenge ${challengeId} has an open or incomplete Approval phase; deferring finalization until it closes.`,
+      );
+      return false;
+    }
+
     const summaries =
       await this.reviewService.getAiDecisionSummaries(challengeId);
 

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -893,48 +893,63 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
         }
       }
 
-      // Block closing Approval until all approval scorecards are submitted
+      // Block closing Approval until all approval scorecards are submitted.
+      // For AI_ONLY challenges (challenges with an AI Review phase) the Approval phase
+      // is a manager-review window with no human reviewer scorecards — skip the
+      // coverage/completion checks and allow the phase to close on its scheduled time.
       if (operation === 'close' && isApprovalPhase) {
         try {
-          const coverage = await this.verifyReviewerCoverage(
-            data.challengeId,
-            data.phaseId,
-            phaseName,
-            true,
+          const approvalChallenge =
+            await this.challengeApiService.getChallengeById(data.challengeId);
+          const isAiOnlyChallenge = (approvalChallenge.phases ?? []).some(
+            (p) => p.name === AI_REVIEW_PHASE_NAME,
           );
 
-          if (!coverage.satisfied) {
-            await this.deferApprovalPhaseClosure(
-              data,
-              undefined,
-              `insufficient approval coverage (${coverage.actual}/${coverage.expected} assigned)`,
-            );
-            return;
-          }
-
-          const pendingApproval =
-            await this.reviewService.getPendingReviewCount(
-              data.phaseId,
+          if (!isAiOnlyChallenge) {
+            const coverage = await this.verifyReviewerCoverage(
               data.challengeId,
-            );
-
-          if (pendingApproval > 0) {
-            await this.deferApprovalPhaseClosure(data, pendingApproval);
-            return;
-          }
-
-          // If there are zero pending reviews, ensure at least one approval review exists
-          const completedCount =
-            await this.reviewService.getCompletedReviewCountForPhase(
               data.phaseId,
+              phaseName,
+              true,
             );
-          if (completedCount === 0) {
-            await this.deferApprovalPhaseClosure(
-              data,
-              0,
-              'no completed approval reviews detected',
+
+            if (!coverage.satisfied) {
+              await this.deferApprovalPhaseClosure(
+                data,
+                undefined,
+                `insufficient approval coverage (${coverage.actual}/${coverage.expected} assigned)`,
+              );
+              return;
+            }
+
+            const pendingApproval =
+              await this.reviewService.getPendingReviewCount(
+                data.phaseId,
+                data.challengeId,
+              );
+
+            if (pendingApproval > 0) {
+              await this.deferApprovalPhaseClosure(data, pendingApproval);
+              return;
+            }
+
+            // If there are zero pending reviews, ensure at least one approval review exists
+            const completedCount =
+              await this.reviewService.getCompletedReviewCountForPhase(
+                data.phaseId,
+              );
+            if (completedCount === 0) {
+              await this.deferApprovalPhaseClosure(
+                data,
+                0,
+                'no completed approval reviews detected',
+              );
+              return;
+            }
+          } else {
+            this.logger.log(
+              `[APPROVAL] AI_ONLY challenge ${data.challengeId}: skipping human reviewer checks for Approval phase ${data.phaseId}; closing on schedule.`,
             );
-            return;
           }
         } catch (error) {
           const err = error as Error;

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -811,6 +811,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       }
 
       // Block closing AI Review (AI_ONLY mode) until all configured AI workflows are completed
+      // and all AI decisions are finalized (not PENDING)
       if (operation === 'close' && isAiReviewPhase) {
         try {
           const challenge = await this.challengeApiService.getChallengeById(
@@ -829,6 +830,21 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
               data,
               inProgressAiWorkflows,
               `${inProgressAiWorkflows} in-progress AI workflow run(s) detected`,
+            );
+            return;
+          }
+
+          // Also check for pending AI decisions
+          const pendingAiDecisions =
+            await this.reviewService.getPendingAiDecisionsCount(
+              data.challengeId,
+            );
+
+          if (pendingAiDecisions > 0) {
+            await this.deferAiScreeningPhaseClosure(
+              data,
+              pendingAiDecisions,
+              `${pendingAiDecisions} pending AI decision(s) detected`,
             );
             return;
           }

--- a/src/challenge/challenge-api.service.spec.ts
+++ b/src/challenge/challenge-api.service.spec.ts
@@ -598,6 +598,183 @@ describe('ChallengeApiService - advancePhase scheduling', () => {
     });
   });
 
+  describe('AI Review phase closure blocking', () => {
+    const buildAiReviewChallenge = (phaseIsOpen: boolean) => ({
+      id: 'challenge-ai-review',
+      name: 'AI Review Challenge',
+      description: null,
+      descriptionFormat: 'markdown',
+      projectId: 789,
+      typeId: 'type-ai',
+      trackId: 'track-ai',
+      timelineTemplateId: 'timeline-ai',
+      currentPhaseNames: phaseIsOpen ? ['AI Review'] : [],
+      tags: [],
+      groups: [],
+      submissionStartDate: fixedNow,
+      submissionEndDate: fixedNow,
+      registrationStartDate: fixedNow,
+      registrationEndDate: fixedNow,
+      startDate: fixedNow,
+      endDate: null,
+      legacyId: null,
+      status: ChallengeStatusEnum.ACTIVE,
+      createdBy: 'tester',
+      updatedBy: 'tester',
+      metadata: {},
+      phases: [
+        {
+          id: 'ai-review-phase',
+          phaseId: 'template-ai-review',
+          name: 'AI Review',
+          description: null,
+          isOpen: phaseIsOpen,
+          predecessor: null,
+          duration: 7200,
+          scheduledStartDate: fixedNow,
+          scheduledEndDate: new Date(fixedNow.getTime() + 7200 * 1000),
+          actualStartDate: phaseIsOpen ? fixedNow : null,
+          actualEndDate: null,
+          constraints: [],
+          createdAt: fixedNow,
+          createdBy: 'tester',
+          updatedAt: fixedNow,
+          updatedBy: 'tester',
+        },
+      ],
+      reviewers: [],
+      winners: [],
+      track: { name: 'DEVELOP' },
+      type: { name: 'Standard' },
+      legacyRecord: null,
+      discussions: [],
+      events: [],
+      prizeSets: [],
+      terms: [],
+      skills: [],
+      attachments: [],
+      overview: {},
+      numOfSubmissions: 1,
+      numOfCheckpointSubmissions: 0,
+      numOfRegistrants: 1,
+      createdAt: fixedNow,
+    });
+
+    it('blocks closing AI Review phase when pending AI decisions exist', async () => {
+      const challengeRecord = buildAiReviewChallenge(true);
+      challengeFindUnique.mockResolvedValueOnce(challengeRecord as any);
+
+      // Mock pending AI decisions count query
+      prisma.$queryRaw = jest.fn().mockResolvedValueOnce([{ count: 3 }]);
+
+      const result = await service.advancePhase(
+        'challenge-ai-review',
+        'ai-review-phase',
+        'close',
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Cannot close AI Review phase');
+      expect(result.message).toContain('3 pending AI decision(s)');
+      expect(dbLogger.logAction).toHaveBeenCalledWith(
+        'challenge.advancePhase',
+        expect.objectContaining({
+          status: 'INFO',
+          details: expect.objectContaining({
+            pendingAiDecisions: 3,
+          }),
+        }),
+      );
+    });
+
+    it('allows closing AI Review phase when no pending AI decisions', async () => {
+      const challengeRecord = buildAiReviewChallenge(true);
+      challengeFindUnique
+        .mockResolvedValueOnce(challengeRecord as any)
+        .mockResolvedValueOnce(challengeRecord as any);
+
+      // Mock no pending AI decisions
+      prisma.$queryRaw = jest.fn().mockResolvedValueOnce([{ count: 0 }]);
+
+      const result = await service.advancePhase(
+        'challenge-ai-review',
+        'ai-review-phase',
+        'close',
+      );
+
+      expect(result.success).toBe(true);
+      expect(prisma.$transaction).toHaveBeenCalled();
+    });
+
+    it('does not check pending AI decisions when opening AI Review phase', async () => {
+      const challengeRecord = buildAiReviewChallenge(false);
+      challengeFindUnique
+        .mockResolvedValueOnce(challengeRecord as any)
+        .mockResolvedValueOnce(challengeRecord as any);
+
+      const queryRawSpy = jest.fn();
+      prisma.$queryRaw = queryRawSpy;
+
+      await service.advancePhase(
+        'challenge-ai-review',
+        'ai-review-phase',
+        'open',
+      );
+
+      // Should not call $queryRaw for pending AI decisions when opening
+      expect(queryRawSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not check pending AI decisions for non-AI Review phases', async () => {
+      const reviewPhase = {
+        id: 'regular-review-phase',
+        phaseId: 'template-review',
+        name: 'Review',
+        description: null,
+        isOpen: true,
+        predecessor: null,
+        duration: 7200,
+        scheduledStartDate: fixedNow,
+        scheduledEndDate: new Date(fixedNow.getTime() + 7200 * 1000),
+        actualStartDate: fixedNow,
+        actualEndDate: null,
+        constraints: [],
+        createdAt: fixedNow,
+        createdBy: 'tester',
+        updatedAt: fixedNow,
+        updatedBy: 'tester',
+      };
+
+      const challengeRecord = {
+        id: 'challenge-regular-review',
+        name: 'Regular Review Challenge',
+        status: ChallengeStatusEnum.ACTIVE,
+        phases: [reviewPhase],
+        currentPhaseNames: ['Review'],
+        reviewers: [],
+        winners: [],
+        track: { name: 'DEVELOP' },
+        type: { name: 'Standard' },
+      };
+
+      challengeFindUnique
+        .mockResolvedValueOnce(challengeRecord as any)
+        .mockResolvedValueOnce(challengeRecord as any);
+
+      const queryRawSpy = jest.fn();
+      prisma.$queryRaw = queryRawSpy;
+
+      await service.advancePhase(
+        'challenge-regular-review',
+        'regular-review-phase',
+        'close',
+      );
+
+      // Should not call $queryRaw for pending AI decisions on non-AI Review phases
+      expect(queryRawSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('createPostMortemPhasePreserving', () => {
     const buildPhase = (overrides: Partial<any> = {}) => {
       const scheduledStart = new Date('2025-09-25T00:00:00.000Z');

--- a/src/challenge/challenge-api.service.ts
+++ b/src/challenge/challenge-api.service.ts
@@ -18,6 +18,7 @@ import {
   isPostMortemPhaseName,
   AI_REVIEW_PHASE_NAME,
 } from '../autopilot/constants/review.constants';
+import { ReviewPrismaService } from 'src/review/review-prisma.service';
 
 // DTO for filtering challenges
 interface ChallengeFiltersDto {
@@ -81,6 +82,7 @@ export class ChallengeApiService {
 
   constructor(
     private readonly prisma: ChallengePrismaService,
+    private readonly reviewPrisma: ReviewPrismaService,
     private readonly dbLogger: AutopilotDbLoggerService,
     private readonly configService: ConfigService,
   ) {
@@ -1856,7 +1858,8 @@ export class ChallengeApiService {
     `;
 
     try {
-      const [record] = await this.prisma.$queryRaw<{ count: number }[]>(query);
+      const [record] =
+        await this.reviewPrisma.$queryRaw<{ count: number }[]>(query);
       const rawCount = Number(record?.count ?? 0);
       return Number.isFinite(rawCount) ? rawCount : 0;
     } catch (error) {

--- a/src/challenge/challenge-api.service.ts
+++ b/src/challenge/challenge-api.service.ts
@@ -16,6 +16,7 @@ import {
   ITERATIVE_REVIEW_PHASE_NAME,
   POST_MORTEM_PHASE_NAMES,
   isPostMortemPhaseName,
+  AI_REVIEW_PHASE_NAME,
 } from '../autopilot/constants/review.constants';
 
 // DTO for filtering challenges
@@ -365,6 +366,29 @@ export class ChallengeApiService {
           details: { phaseId, operation, result },
         });
         return result;
+      }
+
+      // Block closing AI Review phase if there are pending AI decisions
+      const isAiReviewPhase = targetPhase.name === AI_REVIEW_PHASE_NAME;
+      if (operation === 'close' && isAiReviewPhase) {
+        const pendingAiDecisions =
+          await this.getPendingAiDecisionsCount(challengeId);
+        if (pendingAiDecisions > 0) {
+          const result: PhaseAdvanceResponseDto = {
+            success: false,
+            message: `Cannot close AI Review phase: ${pendingAiDecisions} pending AI decision(s) not yet completed`,
+          };
+          void this.dbLogger.logAction('challenge.advancePhase', {
+            challengeId,
+            status: 'INFO',
+            source: ChallengeApiService.name,
+            details: { phaseId, operation, pendingAiDecisions, result },
+          });
+          this.logger.warn(
+            `Blocked closing AI Review phase ${phaseId} for challenge ${challengeId}: ${pendingAiDecisions} pending AI decision(s)`,
+          );
+          return result;
+        }
       }
 
       const now = new Date();
@@ -1806,6 +1830,41 @@ export class ChallengeApiService {
         source: ChallengeApiService.name,
         details: { status, error: err.message },
       });
+      throw err;
+    }
+  }
+
+  /**
+   * Counts AI review decisions in PENDING status for active contest submissions.
+   * Used to block AI Review phase closure until all decisions are finalized.
+   */
+  private async getPendingAiDecisionsCount(
+    challengeId: string,
+  ): Promise<number> {
+    const query = Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM "aiReviewDecision" aid
+      INNER JOIN "submission" s
+        ON s."id" = aid."submissionId"
+      WHERE s."challengeId" = ${challengeId}
+        AND (s."status" = 'ACTIVE' OR s."status" IS NULL)
+        AND (
+          s."type" IS NULL
+          OR UPPER((s."type")::text) = 'CONTEST_SUBMISSION'
+        )
+        AND UPPER((aid."status")::text) = 'PENDING'
+    `;
+
+    try {
+      const [record] = await this.prisma.$queryRaw<{ count: number }[]>(query);
+      const rawCount = Number(record?.count ?? 0);
+      return Number.isFinite(rawCount) ? rawCount : 0;
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        `Failed to count pending AI decisions for challenge ${challengeId}: ${err.message}`,
+        err.stack,
+      );
       throw err;
     }
   }

--- a/src/challenge/challenge-api.service.ts
+++ b/src/challenge/challenge-api.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Prisma, ChallengeStatusEnum, PrizeSetTypeEnum } from '@prisma/client';
 import { ConfigService } from '@nestjs/config';
 import { ChallengePrismaService } from './challenge-prisma.service';
+import { ReviewService } from '../review/review.service';
 import { AutopilotDbLoggerService } from '../autopilot/services/autopilot-db-logger.service';
 import {
   IPhase,
@@ -81,6 +82,7 @@ export class ChallengeApiService {
 
   constructor(
     private readonly prisma: ChallengePrismaService,
+    private readonly reviewService: ReviewService,
     private readonly dbLogger: AutopilotDbLoggerService,
     private readonly configService: ConfigService,
   ) {
@@ -372,7 +374,7 @@ export class ChallengeApiService {
       const isAiReviewPhase = targetPhase.name === AI_REVIEW_PHASE_NAME;
       if (operation === 'close' && isAiReviewPhase) {
         const pendingAiDecisions =
-          await this.getPendingAiDecisionsCount(challengeId);
+          await this.reviewService.getPendingAiDecisionsCount(challengeId);
         if (pendingAiDecisions > 0) {
           const result: PhaseAdvanceResponseDto = {
             success: false,
@@ -1830,42 +1832,6 @@ export class ChallengeApiService {
         source: ChallengeApiService.name,
         details: { status, error: err.message },
       });
-      throw err;
-    }
-  }
-
-  /**
-   * Counts AI review decisions in PENDING status for active contest submissions.
-   * Used to block AI Review phase closure until all decisions are finalized.
-   */
-  private async getPendingAiDecisionsCount(
-    challengeId: string,
-  ): Promise<number> {
-    const query = Prisma.sql`
-      SELECT COUNT(*)::int AS count
-      FROM reviews."aiReviewDecision" aid
-      INNER JOIN reviews."submission" s
-        ON s."id" = aid."submissionId"
-      WHERE s."challengeId" = ${challengeId}
-        AND (s."status" = 'ACTIVE' OR s."status" IS NULL)
-        AND (
-          s."type" IS NULL
-          OR UPPER((s."type")::text) = 'CONTEST_SUBMISSION'
-        )
-        AND UPPER((aid."status")::text) = 'PENDING'
-    `;
-
-    try {
-      const [record] =
-        await this.prisma.$queryRaw<{ count: number }[]>(query);
-      const rawCount = Number(record?.count ?? 0);
-      return Number.isFinite(rawCount) ? rawCount : 0;
-    } catch (error) {
-      const err = error as Error;
-      this.logger.error(
-        `Failed to count pending AI decisions for challenge ${challengeId}: ${err.message}`,
-        err.stack,
-      );
       throw err;
     }
   }

--- a/src/challenge/challenge-api.service.ts
+++ b/src/challenge/challenge-api.service.ts
@@ -18,7 +18,6 @@ import {
   isPostMortemPhaseName,
   AI_REVIEW_PHASE_NAME,
 } from '../autopilot/constants/review.constants';
-import { ReviewPrismaService } from 'src/review/review-prisma.service';
 
 // DTO for filtering challenges
 interface ChallengeFiltersDto {
@@ -82,7 +81,6 @@ export class ChallengeApiService {
 
   constructor(
     private readonly prisma: ChallengePrismaService,
-    private readonly reviewPrisma: ReviewPrismaService,
     private readonly dbLogger: AutopilotDbLoggerService,
     private readonly configService: ConfigService,
   ) {
@@ -1845,8 +1843,8 @@ export class ChallengeApiService {
   ): Promise<number> {
     const query = Prisma.sql`
       SELECT COUNT(*)::int AS count
-      FROM "aiReviewDecision" aid
-      INNER JOIN "submission" s
+      FROM reviews."aiReviewDecision" aid
+      INNER JOIN reviews."submission" s
         ON s."id" = aid."submissionId"
       WHERE s."challengeId" = ${challengeId}
         AND (s."status" = 'ACTIVE' OR s."status" IS NULL)
@@ -1859,7 +1857,7 @@ export class ChallengeApiService {
 
     try {
       const [record] =
-        await this.reviewPrisma.$queryRaw<{ count: number }[]>(query);
+        await this.prisma.$queryRaw<{ count: number }[]>(query);
       const rawCount = Number(record?.count ?? 0);
       return Number.isFinite(rawCount) ? rawCount : 0;
     } catch (error) {

--- a/src/challenge/challenge.module.ts
+++ b/src/challenge/challenge.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ChallengeApiService } from './challenge-api.service';
 import { ChallengePrismaService } from './challenge-prisma.service';
+import { ReviewModule } from '../review/review.module';
 
 @Module({
+  imports: [ReviewModule],
   providers: [ChallengeApiService, ChallengePrismaService],
   exports: [ChallengeApiService],
 })

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -3324,6 +3324,54 @@ export class ReviewService {
     }
   }
 
+  /**
+   * Counts AI review decisions in PENDING status for active contest submissions.
+   * Used to block AI Review phase closure until all decisions are finalized.
+   */
+  async getPendingAiDecisionsCount(challengeId: string): Promise<number> {
+    const query = Prisma.sql`
+      SELECT COUNT(*)::int AS count
+      FROM ${ReviewService.AI_REVIEW_DECISION_TABLE} aid
+      INNER JOIN ${ReviewService.SUBMISSION_TABLE} s
+        ON s."id" = aid."submissionId"
+      WHERE s."challengeId" = ${challengeId}
+        AND (s."status" = 'ACTIVE' OR s."status" IS NULL)
+        AND (
+          s."type" IS NULL
+          OR UPPER((s."type")::text) = 'CONTEST_SUBMISSION'
+        )
+        AND UPPER((aid."status")::text) = 'PENDING'
+    `;
+
+    try {
+      const [record] = await this.prisma.$queryRaw<PendingCountRecord[]>(query);
+      const rawCount = Number(record?.count ?? 0);
+      const count = Number.isFinite(rawCount) ? rawCount : 0;
+
+      void this.dbLogger.logAction('review.getPendingAiDecisionsCount', {
+        challengeId,
+        status: 'SUCCESS',
+        source: ReviewService.name,
+        details: {
+          pendingAiDecisions: count,
+        },
+      });
+
+      return count;
+    } catch (error) {
+      const err = error as Error;
+      void this.dbLogger.logAction('review.getPendingAiDecisionsCount', {
+        challengeId,
+        status: 'ERROR',
+        source: ReviewService.name,
+        details: {
+          error: err.message,
+        },
+      });
+      throw err;
+    }
+  }
+
   async getInProgressAiWorkflowRunCount(
     challengeId: string,
     aiWorkflowIds: string[],

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -997,6 +997,7 @@ export class ReviewService {
           d."submissionId",
           d."totalScore",
           UPPER((d."status")::text) AS "status",
+          c."minPassingThreshold",
           ROW_NUMBER() OVER (
             PARTITION BY d."submissionId"
             ORDER BY
@@ -1016,7 +1017,8 @@ export class ReviewService {
         s."memberId"             AS "memberId",
         s."submittedDate"        AS "submittedDate",
         COALESCE(rd."totalScore", 0) AS "totalScore",
-        rd."status"              AS "status"
+        rd."status"              AS "status",
+        rd."minPassingThreshold" AS "minPassingThreshold"
       FROM ${ReviewService.SUBMISSION_TABLE} s
       INNER JOIN ranked_decisions rd ON rd."submissionId" = s."id"
       WHERE s."challengeId" = ${challengeId}
@@ -1037,14 +1039,27 @@ export class ReviewService {
           submittedDate: Date | null;
           totalScore: string | number;
           status: string;
+          minPassingThreshold: string | number | null;
         }[]
       >(query);
 
       return rows.map((row) => {
         const rawScore = Number(row.totalScore);
         const aggregateScore = Number.isFinite(rawScore) ? rawScore : 0;
-        const isPassing =
-          row.status === 'PASSED' || row.status === 'HUMAN_OVERRIDE';
+        const minPassingThreshold = Number(row.minPassingThreshold);
+        const hasValidThreshold = Number.isFinite(minPassingThreshold);
+
+        let isPassing: boolean;
+        if (row.status === 'PASSED') {
+          isPassing = true;
+        } else if (row.status === 'HUMAN_OVERRIDE') {
+          // For HUMAN_OVERRIDE, check score against minPassingThreshold
+          isPassing = hasValidThreshold
+            ? aggregateScore >= minPassingThreshold
+            : true;
+        } else {
+          isPassing = false;
+        }
 
         return {
           submissionId: row.submissionId,
@@ -1054,7 +1069,7 @@ export class ReviewService {
           aggregateScore,
           scorecardId: null,
           scorecardLegacyId: null,
-          passingScore: 0,
+          passingScore: hasValidThreshold ? minPassingThreshold : 0,
           isPassing,
         };
       });


### PR DESCRIPTION
This pull request introduces several important changes to improve the handling and reliability of AI Review and Approval phases in the challenge workflow. The main focus is to ensure that phases are only closed when all necessary AI decisions are finalized, and to correctly handle the Approval phase for AI-only challenges. Additional improvements include more robust passing score logic and enhanced test coverage.

**AI Review and Approval Phase Handling:**

* Added logic to block closing the AI Review phase if there are any pending AI decisions for active contest submissions, both in `ChallengeApiService` and `SchedulerService`, ensuring that all AI decisions are finalized before phase closure. [[1]](diffhunk://#diff-2b93a8c4b4b67e61418dacef17dde4839d4cea06de4930305721b96a8f278002R371-R393) [[2]](diffhunk://#diff-f65844bce2a9c66523f2013866dec15ff1dbe7fd72f5d7f64e74c7f8b021eb5aR814) [[3]](diffhunk://#diff-f65844bce2a9c66523f2013866dec15ff1dbe7fd72f5d7f64e74c7f8b021eb5aR836-R850) [[4]](diffhunk://#diff-ac5e9fa87de1fd9c47202160a7d7f5a280eec49541093e76c1cc2612a0b9e4a9R3327-R3374)
* For AI-only challenges, the Approval phase now skips human reviewer checks and closes on schedule, as there are no human reviewer scorecards required. [[1]](diffhunk://#diff-f65844bce2a9c66523f2013866dec15ff1dbe7fd72f5d7f64e74c7f8b021eb5aL896-R924) [[2]](diffhunk://#diff-f65844bce2a9c66523f2013866dec15ff1dbe7fd72f5d7f64e74c7f8b021eb5aR965-R969)

**Review and Passing Score Logic:**

* Improved the logic for determining passing scores: for submissions with a HUMAN_OVERRIDE status, the code now checks if the score meets the minimum passing threshold instead of always marking as passing. [[1]](diffhunk://#diff-ac5e9fa87de1fd9c47202160a7d7f5a280eec49541093e76c1cc2612a0b9e4a9R1000) [[2]](diffhunk://#diff-ac5e9fa87de1fd9c47202160a7d7f5a280eec49541093e76c1cc2612a0b9e4a9L1019-R1021) [[3]](diffhunk://#diff-ac5e9fa87de1fd9c47202160a7d7f5a280eec49541093e76c1cc2612a0b9e4a9R1042-R1062) [[4]](diffhunk://#diff-ac5e9fa87de1fd9c47202160a7d7f5a280eec49541093e76c1cc2612a0b9e4a9L1057-R1072)

**Challenge Finalization Logic:**

* In `ChallengeCompletionService`, finalization is now deferred if the Approval phase is still open or incomplete, ensuring winners are only determined after all manager overrides are applied. Also, `finalizeSummations` is now called after these checks. [[1]](diffhunk://#diff-68774c83708ba608097c7817613af4ea0889628b8154db7ec356341575a44e5aL594-L595) [[2]](diffhunk://#diff-68774c83708ba608097c7817613af4ea0889628b8154db7ec356341575a44e5aR607) [[3]](diffhunk://#diff-68774c83708ba608097c7817613af4ea0889628b8154db7ec356341575a44e5aR764-R780)

**Testing Improvements:**

* Added comprehensive tests to verify that the AI Review phase cannot be closed with pending AI decisions, and that non-AI phases and phase openings are unaffected.

**Other:**

* Added a new `deploy:dev` script to `package.json` for streamlined development deployments.