### PR TITLE
PM-5051: Rerate completed challenge updates

### DIFF
--- a/src/autopilot/services/phase-schedule-manager.service.spec.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.spec.ts
@@ -43,6 +43,7 @@ describe('PhaseScheduleManager', () => {
     generateChallengePayments: jest.Mock;
   };
   let memberApiService: {
+    rerateChallengeSubmitterRatings: jest.Mock;
     syncChallengePoints: jest.Mock;
   };
   let first2FinishService: {
@@ -88,6 +89,7 @@ describe('PhaseScheduleManager', () => {
     };
 
     memberApiService = {
+      rerateChallengeSubmitterRatings: jest.fn().mockResolvedValue(true),
       syncChallengePoints: jest.fn().mockResolvedValue(true),
     };
 
@@ -136,6 +138,12 @@ describe('PhaseScheduleManager', () => {
     expect(financeApiService.generateChallengePayments).toHaveBeenCalledWith(
       'challenge-1',
     );
+    expect(
+      memberApiService.rerateChallengeSubmitterRatings,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      memberApiService.rerateChallengeSubmitterRatings,
+    ).toHaveBeenCalledWith('challenge-1');
   });
 
   it('syncs challenge points once when a point-prize challenge transitions to COMPLETED', async () => {
@@ -304,6 +312,9 @@ describe('PhaseScheduleManager', () => {
     });
 
     expect(financeApiService.generateChallengePayments).not.toHaveBeenCalled();
+    expect(
+      memberApiService.rerateChallengeSubmitterRatings,
+    ).not.toHaveBeenCalled();
   });
 
   it('triggers finance generation when an ACTIVE challenge becomes COMPLETED after immediate phase closures', async () => {
@@ -350,6 +361,12 @@ describe('PhaseScheduleManager', () => {
     expect(financeApiService.generateChallengePayments).toHaveBeenCalledWith(
       'challenge-3',
     );
+    expect(
+      memberApiService.rerateChallengeSubmitterRatings,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      memberApiService.rerateChallengeSubmitterRatings,
+    ).toHaveBeenCalledWith('challenge-3');
   });
 
   it('processes unchanged open review phases only once during manual phase detection', async () => {

--- a/src/autopilot/services/phase-schedule-manager.service.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.ts
@@ -356,6 +356,10 @@ export class PhaseScheduleManager {
         challengeDetails,
         previousStatus,
       );
+      this.triggerChallengeRatingRerateForCompletedStatus(
+        challengeDetails,
+        previousStatus,
+      );
 
       if (!isActiveStatus(challengeDetails.status)) {
         this.updateCachedStatus(message.id, challengeDetails.status);
@@ -387,6 +391,10 @@ export class PhaseScheduleManager {
             challengeDetails.status,
           );
           this.triggerChallengePointsSyncForPayableStatus(
+            challengeDetails,
+            previousStatus,
+          );
+          this.triggerChallengeRatingRerateForCompletedStatus(
             challengeDetails,
             previousStatus,
           );
@@ -616,6 +624,47 @@ export class PhaseScheduleManager {
       const err = error as Error;
       this.logger.error(
         `[POINTS] Failed to trigger challenge points sync for challenge ${challenge.id}: ${err.message}`,
+        err.stack,
+      );
+    }
+  }
+
+  /**
+   * Starts member-api rating recalculation when a challenge becomes completed.
+   * @param challenge Challenge snapshot containing status and id.
+   * @param previousStatus Last cached challenge status, if known.
+   * @returns Nothing. The outbound call is started without blocking update handling.
+   * @throws Never. Errors are logged and swallowed so update handling remains idempotent.
+   *
+   * Usage:
+   * Invoked from challenge update handling for completions that are observed
+   * outside `ChallengeCompletionService`, such as manually completed challenges.
+   * Member-api determines whether the challenge is rated and which native or
+   * named rating dimensions should be recalculated.
+   */
+  private triggerChallengeRatingRerateForCompletedStatus(
+    challenge: IChallenge,
+    previousStatus: string | null,
+  ): void {
+    const currentStatus = challenge.status?.toUpperCase();
+    if (currentStatus !== ChallengeStatusEnum.COMPLETED) {
+      return;
+    }
+
+    if (previousStatus && previousStatus.toUpperCase() === currentStatus) {
+      return;
+    }
+
+    if (!this.memberApiService) {
+      return;
+    }
+
+    try {
+      void this.memberApiService.rerateChallengeSubmitterRatings(challenge.id);
+    } catch (error) {
+      const err = error as Error;
+      this.logger.error(
+        `[RATINGS] Failed to trigger challenge submitter rating rerate for challenge ${challenge.id}: ${err.message}`,
         err.stack,
       );
     }


### PR DESCRIPTION
What was broken

The earlier member-api fix corrected Marathon Match rerate eligibility, but autopilot's challenge status-update path only triggered finance and point sync when it observed a challenge becoming COMPLETED. Challenges completed outside ChallengeCompletionService could miss the member-api challenge-level rerate call.

Root cause

The automatic rerate hook was added to ChallengeCompletionService, while PhaseScheduleManager's completed-status reconciliation path was left with only payment and point side effects.

What was changed

PhaseScheduleManager now calls memberApiService.rerateChallengeSubmitterRatings once when an update transitions a challenge to COMPLETED, including the path where overdue phase processing refreshes the challenge into COMPLETED. Member-api still decides whether the challenge is rated and which native or named rating dimensions apply.

Any added/updated tests

Updated PhaseScheduleManager unit coverage to assert the completed-status update path triggers submitter rerating once, skips non-completed statuses, and rerates when immediate phase closures complete the challenge.

Validation:

- source ~/.nvm/nvm.sh && nvm use && pnpm test -- phase-schedule-manager.service.spec.ts
- source ~/.nvm/nvm.sh && nvm use && pnpm test
- source ~/.nvm/nvm.sh && nvm use && pnpm build
- source ~/.nvm/nvm.sh && nvm use && pnpm exec eslint src/autopilot/services/phase-schedule-manager.service.ts src/autopilot/services/phase-schedule-manager.service.spec.ts
- source ~/.nvm/nvm.sh && nvm use && pnpm lint was run, but it fails on existing unrelated lint errors in files outside this PM-5051 change, such as first2finish.service.spec.ts, phase-review.service.spec.ts, challenge-api.service.spec.ts, finance-api.service.ts, kafka.service.ts, review-api.service.ts, and review.service.spec.ts.
