### PR TITLE
When advancing AI phase, count the pending workflows for latest submissions only

### DIFF
--- a/src/review/review.service.spec.ts
+++ b/src/review/review.service.spec.ts
@@ -219,6 +219,44 @@ describe('ReviewService', () => {
     });
   });
 
+  describe('getInProgressAiWorkflowRunCount', () => {
+    it('counts only in-progress AI workflow runs for latest submissions', async () => {
+      prismaMock.$queryRaw.mockResolvedValueOnce([{ count: '4' }]);
+
+      const count = await service.getInProgressAiWorkflowRunCount(
+        challengeId,
+        ['workflow-ai-1', 'workflow-ai-2'],
+      );
+
+      expect(count).toBe(4);
+
+      const rawQuery = prismaMock.$queryRaw.mock.calls[0][0] as {
+        strings?: TemplateStringsArray | string[];
+      };
+      const sqlText = Array.isArray(rawQuery?.strings)
+        ? rawQuery.strings.join('')
+        : '';
+
+      expect(sqlText).toContain('WITH latest_submissions AS');
+      expect(sqlText).toContain('ROW_NUMBER() OVER (');
+      expect(sqlText).toContain('PARTITION BY COALESCE(s."memberId", s."id")');
+      expect(sqlText).toContain('awr."workflowId" IN');
+      expect(sqlText).toContain('UPPER((awr."status")::text) IN');
+
+      expect(dbLoggerMock.logAction).toHaveBeenCalledWith(
+        'review.getInProgressAiWorkflowRunCount',
+        expect.objectContaining({
+          status: 'SUCCESS',
+          details: expect.objectContaining({
+            workflowCount: 2,
+            inProgressCount: 4,
+            latestSubmissionsOnly: true,
+          }),
+        }),
+      );
+    });
+  });
+
   describe('buildChallengeResultRecordsForChallenge', () => {
     it('prefers the latest submission when submissions are limited', async () => {
       prismaMock.$queryRaw.mockResolvedValue([

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -3391,12 +3391,38 @@ export class ReviewService {
     const inProgressStatuses = ['INIT', 'QUEUED', 'DISPATCHED', 'IN_PROGRESS'];
 
     const query = Prisma.sql`
+      WITH latest_submissions AS (
+        SELECT latest."id"
+        FROM (
+          SELECT
+            s."id",
+            ROW_NUMBER() OVER (
+              PARTITION BY COALESCE(s."memberId", s."id")
+              ORDER BY
+                s."submittedDate" DESC NULLS LAST,
+                s."createdAt" DESC NULLS LAST,
+                s."updatedAt" DESC NULLS LAST,
+                s."id" DESC
+            ) AS row_num
+          FROM ${ReviewService.SUBMISSION_TABLE} s
+          WHERE s."challengeId" = ${challengeId}
+            AND (
+              s."status" IS NULL
+              OR s."status" = 'ACTIVE'
+              OR s."status" = 'AI_FAILED_REVIEW'
+            )
+            AND (
+              s."type" IS NULL
+              OR UPPER((s."type")::text) = 'CONTEST_SUBMISSION'
+            )
+        ) latest
+        WHERE latest.row_num = 1
+      )
       SELECT COUNT(*)::int AS count
       FROM ${ReviewService.AI_WORKFLOW_RUN_TABLE} awr
-      INNER JOIN ${ReviewService.SUBMISSION_TABLE} s
-        ON s."id" = awr."submissionId"
-      WHERE s."challengeId" = ${challengeId}
-        AND awr."workflowId" IN (${Prisma.join(normalizedWorkflowIds)})
+      INNER JOIN latest_submissions ls
+        ON ls."id" = awr."submissionId"
+      WHERE awr."workflowId" IN (${Prisma.join(normalizedWorkflowIds)})
         AND UPPER((awr."status")::text) IN (${Prisma.join(inProgressStatuses)})
     `;
 
@@ -3412,6 +3438,7 @@ export class ReviewService {
         details: {
           workflowCount: normalizedWorkflowIds.length,
           inProgressCount: count,
+          latestSubmissionsOnly: true,
         },
       });
 


### PR DESCRIPTION
This pull request enhances the logic for counting in-progress AI workflow runs in the `ReviewService` to consider only the latest submissions per user or submission, ensuring more accurate metrics. It also adds comprehensive tests to verify the new behavior and improves logging details for better observability.

**Improvements to AI workflow run counting:**

* Updated the SQL query in `getInProgressAiWorkflowRunCount` to use a Common Table Expression (`latest_submissions`) that selects only the latest submission for each user or submission, ensuring that only in-progress workflow runs for these are counted.

**Testing enhancements:**

* Added a new test case in `review.service.spec.ts` to verify that `getInProgressAiWorkflowRunCount` correctly counts only in-progress AI workflow runs for the latest submissions and checks the generated SQL for expected clauses.

**Logging improvements:**

* Enhanced the action logging in `getInProgressAiWorkflowRunCount` to include a `latestSubmissionsOnly: true` flag in the log details, making it clear that only the latest submissions are considered.