### PR TITLE
PM-5665 instant review

### DIFF
--- a/src/autopilot/services/autopilot.service.ts
+++ b/src/autopilot/services/autopilot.service.ts
@@ -892,6 +892,14 @@ export class AutopilotService {
     }
   }
 
+  async handleAiPhaseOpened(payload: PhaseTransitionPayload): Promise<void> {
+    const { challengeId, phaseId } = payload;
+
+    this.logger.debug(
+      `Received AI phase opened event for challenge ${challengeId}, phase ${phaseId}; ignoring in autopilot consumer.`,
+    );
+  }
+
   private resolvePhaseByIdentifier(
     challenge: IChallenge,
     phaseReference: string | null | undefined,

--- a/src/autopilot/services/phase-schedule-manager.service.spec.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.spec.ts
@@ -26,9 +26,13 @@ describe('PhaseScheduleManager', () => {
   };
   let challengeApiService: {
     getChallengeById: jest.Mock;
+    getPhaseDetails: jest.Mock;
   };
   let phaseReviewService: {
     handlePhaseOpenedForChallenge: jest.Mock;
+  };
+  let reviewAssignmentService: {
+    clearPolling: jest.Mock;
   };
   let reviewApiService: {
     createReviewOpportunity: jest.Mock;
@@ -37,6 +41,7 @@ describe('PhaseScheduleManager', () => {
   let reviewService: {
     getMarathonMatchReviewReadiness: jest.Mock;
     updatePendingReviewScorecards: jest.Mock;
+    getInProgressAiWorkflowRunCount: jest.Mock;
   };
   let dbLogger: {
     logAction: jest.Mock;
@@ -67,10 +72,15 @@ describe('PhaseScheduleManager', () => {
 
     challengeApiService = {
       getChallengeById: jest.fn(),
+      getPhaseDetails: jest.fn(),
     };
 
     phaseReviewService = {
       handlePhaseOpenedForChallenge: jest.fn().mockResolvedValue(undefined),
+    };
+
+    reviewAssignmentService = {
+      clearPolling: jest.fn().mockResolvedValue(undefined),
     };
 
     reviewApiService = {
@@ -86,6 +96,7 @@ describe('PhaseScheduleManager', () => {
         finalScoreSubmissionCount: 0,
       }),
       updatePendingReviewScorecards: jest.fn().mockResolvedValue(0),
+      getInProgressAiWorkflowRunCount: jest.fn().mockResolvedValue(0),
     };
 
     dbLogger = {
@@ -109,7 +120,7 @@ describe('PhaseScheduleManager', () => {
       schedulerService as unknown as SchedulerService,
       challengeApiService as unknown as ChallengeApiService,
       phaseReviewService as unknown as PhaseReviewService,
-      {} as unknown as ReviewAssignmentService,
+      reviewAssignmentService as unknown as ReviewAssignmentService,
       reviewService as unknown as ReviewService,
       reviewApiService as unknown as ReviewApiService,
       {
@@ -548,6 +559,60 @@ describe('PhaseScheduleManager', () => {
       expect.objectContaining({
         challengeId: 'challenge-iterative',
         type: 'ITERATIVE_REVIEW',
+      }),
+    );
+  });
+
+  it('opens AI Screening phases via SchedulerService advancePhase during phase chain to preserve AI phase open semantics', async () => {
+    const aiPhase = {
+      id: 'ai-screening-phase',
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: false,
+      scheduledStartDate: '2026-05-01T00:00:00.000Z',
+      scheduledEndDate: '2026-05-02T00:00:00.000Z',
+    };
+
+    challengeApiService.getPhaseDetails.mockResolvedValueOnce({
+      ...aiPhase,
+      isOpen: true,
+    });
+    challengeApiService.getChallengeById.mockResolvedValueOnce({
+      id: 'challenge-ai',
+      reviewers: [],
+    });
+    reviewService.getInProgressAiWorkflowRunCount.mockResolvedValueOnce(1);
+
+    await (service as unknown as { openPhaseAndSchedule: (
+      challengeId: string,
+      projectId: number,
+      projectStatus: string,
+      phase: unknown,
+    ) => Promise<boolean> }).openPhaseAndSchedule(
+      'challenge-ai',
+      1001,
+      'ACTIVE',
+      aiPhase,
+    );
+
+    expect(schedulerService.advancePhase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        challengeId: 'challenge-ai',
+        phaseId: aiPhase.id,
+        phaseTypeName: aiPhase.name,
+        state: 'START',
+        operator: AutopilotOperator.SYSTEM_PHASE_CHAIN,
+        projectStatus: 'ACTIVE',
+      }),
+    );
+    expect(challengeApiService.getChallengeById).toHaveBeenCalledWith(
+      'challenge-ai',
+    );
+    expect(schedulerService.schedulePhaseTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        challengeId: 'challenge-ai',
+        phaseId: aiPhase.id,
+        state: 'END',
       }),
     );
   });

--- a/src/autopilot/services/phase-schedule-manager.service.spec.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.spec.ts
@@ -42,6 +42,7 @@ describe('PhaseScheduleManager', () => {
     getMarathonMatchReviewReadiness: jest.Mock;
     updatePendingReviewScorecards: jest.Mock;
     getInProgressAiWorkflowRunCount: jest.Mock;
+    isInstantReviewEnabledForChallenge: jest.Mock;
   };
   let dbLogger: {
     logAction: jest.Mock;
@@ -97,6 +98,7 @@ describe('PhaseScheduleManager', () => {
       }),
       updatePendingReviewScorecards: jest.fn().mockResolvedValue(0),
       getInProgressAiWorkflowRunCount: jest.fn().mockResolvedValue(0),
+      isInstantReviewEnabledForChallenge: jest.fn().mockResolvedValue(true),
     };
 
     dbLogger = {
@@ -614,6 +616,54 @@ describe('PhaseScheduleManager', () => {
         phaseId: aiPhase.id,
         state: 'END',
       }),
+    );
+  });
+
+  it('preserves AI Screening open phase when instantReview is disabled and skips workflow auto-close', async () => {
+    const aiPhase = {
+      id: 'ai-screening-phase-disabled',
+      phaseId: 'ai-screening-template-disabled',
+      name: 'AI Screening',
+      isOpen: false,
+      scheduledStartDate: '2026-05-01T00:00:00.000Z',
+      scheduledEndDate: '2026-05-02T00:00:00.000Z',
+    };
+
+    challengeApiService.getPhaseDetails.mockResolvedValueOnce({
+      ...aiPhase,
+      isOpen: true,
+    });
+    challengeApiService.getChallengeById.mockResolvedValueOnce({
+      id: 'challenge-ai-disabled',
+      reviewers: [],
+    });
+    reviewService.isInstantReviewEnabledForChallenge.mockResolvedValueOnce(
+      false,
+    );
+
+    const opened = await (service as unknown as {
+      openPhaseAndSchedule: (
+        challengeId: string,
+        projectId: number,
+        projectStatus: string,
+        phase: unknown,
+      ) => Promise<boolean>;
+    }).openPhaseAndSchedule('challenge-ai-disabled', 1002, 'ACTIVE', aiPhase);
+
+    expect(opened).toBe(true);
+    expect(reviewService.isInstantReviewEnabledForChallenge).toHaveBeenCalledWith(
+      'challenge-ai-disabled',
+    );
+    expect(reviewService.getInProgressAiWorkflowRunCount).not.toHaveBeenCalled();
+    expect(schedulerService.advancePhase).toHaveBeenCalledTimes(1);
+    expect(schedulerService.advancePhase).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'START' }),
+    );
+    expect(schedulerService.advancePhase).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'END' }),
+    );
+    expect(schedulerService.schedulePhaseTransition).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'END' }),
     );
   });
 });

--- a/src/autopilot/services/phase-schedule-manager.service.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.ts
@@ -17,6 +17,7 @@ import {
   PhaseTransitionPayload,
 } from '../interfaces/autopilot.interface';
 import {
+  AI_REVIEW_PHASE_NAME,
   AI_SCREENING_PHASE_NAME,
   APPROVAL_PHASE_NAMES,
   CHECKPOINT_SUBMISSION_PHASE_NAME,
@@ -1557,39 +1558,94 @@ export class PhaseScheduleManager {
       `[PHASE CHAIN] Opening phase ${phase.name} (${phase.id}) for challenge ${challengeId}`,
     );
 
-    const openResult = await this.challengeApiService.advancePhase(
-      challengeId,
-      phase.id,
-      'open',
-    );
+    const isAiPhase =
+      this.isAiScreeningPhaseName(phase.name) ||
+      this.isAiReviewPhaseName(phase.name);
 
-    if (!openResult.success) {
-      this.logger.error(
-        `[PHASE CHAIN] Failed to open phase ${phase.name} (${phase.id}) for challenge ${challengeId}: ${openResult.message}`,
+    let updatedPhase: IPhase | null = phase;
+
+    if (isAiPhase) {
+      try {
+        await this.schedulerService.advancePhase({
+          projectId,
+          challengeId,
+          phaseId: phase.id,
+          phaseTypeName: phase.name,
+          state: 'START',
+          operator: AutopilotOperator.SYSTEM_PHASE_CHAIN,
+          projectStatus,
+          date: new Date().toISOString(),
+        });
+      } catch (error) {
+        const err = error as Error;
+        this.logger.error(
+          `[PHASE CHAIN] Failed to open AI phase ${phase.name} (${phase.id}) for challenge ${challengeId}: ${err.message}`,
+          err.stack,
+        );
+        return false;
+      }
+
+      try {
+        updatedPhase = await this.challengeApiService.getPhaseDetails(
+          challengeId,
+          phase.id,
+        );
+      } catch (error) {
+        const err = error as Error;
+        this.logger.error(
+          `[PHASE CHAIN] Failed to fetch phase details after opening AI phase ${phase.name} (${phase.id}) for challenge ${challengeId}: ${err.message}`,
+          err.stack,
+        );
+        return false;
+      }
+
+      if (!updatedPhase || !updatedPhase.isOpen) {
+        this.logger.log(
+          `[PHASE CHAIN] AI phase ${phase.name} (${phase.id}) for challenge ${challengeId} is no longer open after scheduler-managed open; skipping scheduling.`,
+        );
+        return true;
+      }
+
+      this.reviewAssignmentService.clearPolling(challengeId, phase.id);
+
+      this.logger.log(
+        `[PHASE CHAIN] Successfully opened AI phase ${phase.name} (${phase.id}) for challenge ${challengeId}`,
       );
-      return false;
-    }
-
-    this.reviewAssignmentService.clearPolling(challengeId, phase.id);
-
-    this.logger.log(
-      `[PHASE CHAIN] Successfully opened phase ${phase.name} (${phase.id}) for challenge ${challengeId}`,
-    );
-
-    // Create pending reviews for any review-related phases (Review, Screening, Approval).
-    // PhaseReviewService will ignore non review phases.
-    try {
-      await this.phaseReviewService.handlePhaseOpened(challengeId, phase.id);
-    } catch (error) {
-      const err = error as Error;
-      this.logger.error(
-        `[PHASE CHAIN] Failed to prepare review records for phase ${phase.name} (${phase.id}) on challenge ${challengeId}: ${err.message}`,
-        err.stack,
+    } else {
+      const openResult = await this.challengeApiService.advancePhase(
+        challengeId,
+        phase.id,
+        'open',
       );
-    }
 
-    const updatedPhase =
-      openResult.updatedPhases?.find((p) => p.id === phase.id) || phase;
+      if (!openResult.success) {
+        this.logger.error(
+          `[PHASE CHAIN] Failed to open phase ${phase.name} (${phase.id}) for challenge ${challengeId}: ${openResult.message}`,
+        );
+        return false;
+      }
+
+      this.reviewAssignmentService.clearPolling(challengeId, phase.id);
+
+      this.logger.log(
+        `[PHASE CHAIN] Successfully opened phase ${phase.name} (${phase.id}) for challenge ${challengeId}`,
+      );
+
+      // Create pending reviews for any review-related phases (Review, Screening, Approval).
+      // PhaseReviewService will ignore non review phases.
+      try {
+        await this.phaseReviewService.handlePhaseOpened(challengeId, phase.id);
+      } catch (error) {
+        const err = error as Error;
+        this.logger.error(
+          `[PHASE CHAIN] Failed to prepare review records for phase ${phase.name} (${phase.id}) on challenge ${challengeId}: ${err.message}`,
+          err.stack,
+        );
+      }
+
+      updatedPhase =
+        openResult.updatedPhases?.find((p) => p.id === phase.id) || phase;
+    }
 
     const updatedScheduledStart = updatedPhase.scheduledStartDate
       ? new Date(updatedPhase.scheduledStartDate).getTime()
@@ -1736,6 +1792,10 @@ export class PhaseScheduleManager {
 
   private isAiScreeningPhaseName(phaseName?: string | null): boolean {
     return phaseName?.trim() === AI_SCREENING_PHASE_NAME;
+  }
+
+  private isAiReviewPhaseName(phaseName?: string | null): boolean {
+    return phaseName?.trim() === AI_REVIEW_PHASE_NAME;
   }
 
   private getAiWorkflowIdsForChallenge(challenge: IChallenge): string[] {

--- a/src/autopilot/services/phase-schedule-manager.service.ts
+++ b/src/autopilot/services/phase-schedule-manager.service.ts
@@ -1710,42 +1710,62 @@ export class PhaseScheduleManager {
     }
 
     if (this.isAiScreeningPhaseName(updatedPhase.name)) {
+      let instantReviewEnabled = true;
       try {
-        const challenge =
-          await this.challengeApiService.getChallengeById(challengeId);
-        const aiWorkflowIds = this.getAiWorkflowIdsForChallenge(challenge);
-
-        const inProgressAiWorkflows =
-          await this.reviewService.getInProgressAiWorkflowRunCount(
+        instantReviewEnabled =
+          await this.reviewService.isInstantReviewEnabledForChallenge(
             challengeId,
-            aiWorkflowIds,
           );
-
-        if (inProgressAiWorkflows === 0) {
-          this.logger.log(
-            `[AI SCREENING] No pending AI workflow runs for challenge ${challengeId}; closing phase ${updatedPhase.id} immediately after open.`,
-          );
-
-          const closePayload: PhaseTransitionPayload = {
-            projectId,
-            challengeId,
-            phaseId: updatedPhase.id,
-            phaseTypeName: updatedPhase.name,
-            state: 'END',
-            operator: AutopilotOperator.SYSTEM_PHASE_CHAIN,
-            projectStatus,
-            date: new Date().toISOString(),
-          };
-
-          await this.schedulerService.advancePhase(closePayload);
-          return true;
-        }
       } catch (error) {
         const err = error as Error;
         this.logger.error(
-          `[AI SCREENING] Unable to evaluate pending AI workflow runs for challenge ${challengeId}, phase ${updatedPhase.id}: ${err.message}`,
+          `[AI SCREENING] Unable to determine instantReview readiness for challenge ${challengeId}, phase ${updatedPhase.id}: ${err.message}`,
           err.stack,
         );
+      }
+
+      if (!instantReviewEnabled) {
+        this.logger.log(
+          `[AI SCREENING] instantReview disabled for challenge ${challengeId}; preserving open phase ${updatedPhase.id} and scheduling closure normally at ${updatedPhase.scheduledEndDate}.`,
+        );
+      } else {
+        try {
+          const challenge =
+            await this.challengeApiService.getChallengeById(challengeId);
+          const aiWorkflowIds = this.getAiWorkflowIdsForChallenge(challenge);
+
+          const inProgressAiWorkflows =
+            await this.reviewService.getInProgressAiWorkflowRunCount(
+              challengeId,
+              aiWorkflowIds,
+            );
+
+          if (inProgressAiWorkflows === 0) {
+            this.logger.log(
+              `[AI SCREENING] No pending AI workflow runs for challenge ${challengeId}; closing phase ${updatedPhase.id} immediately after open.`,
+            );
+
+            const closePayload: PhaseTransitionPayload = {
+              projectId,
+              challengeId,
+              phaseId: updatedPhase.id,
+              phaseTypeName: updatedPhase.name,
+              state: 'END',
+              operator: AutopilotOperator.SYSTEM_PHASE_CHAIN,
+              projectStatus,
+              date: new Date().toISOString(),
+            };
+
+            await this.schedulerService.advancePhase(closePayload);
+            return true;
+          }
+        } catch (error) {
+          const err = error as Error;
+          this.logger.error(
+            `[AI SCREENING] Unable to evaluate pending AI workflow runs for challenge ${challengeId}, phase ${updatedPhase.id}: ${err.message}`,
+            err.stack,
+          );
+        }
       }
     }
 

--- a/src/autopilot/services/scheduler.service.spec.ts
+++ b/src/autopilot/services/scheduler.service.spec.ts
@@ -59,6 +59,9 @@ type ReviewServiceMock = {
   getActiveContestSubmissionIds: MockedMethod<
     ReviewService['getActiveContestSubmissionIds']
   >;
+  isInstantReviewEnabledForChallenge: MockedMethod<
+    ReviewService['isInstantReviewEnabledForChallenge']
+  >;
   getFailedScreeningSubmissionIds: MockedMethod<
     ReviewService['getFailedScreeningSubmissionIds']
   >;
@@ -229,6 +232,8 @@ describe('SchedulerService (review phase deferral)', () => {
         createMockMethod<ReviewService['getCompletedReviewCountForPhase']>(),
       getInProgressAiWorkflowRunCount:
         createMockMethod<ReviewService['getInProgressAiWorkflowRunCount']>(),
+      isInstantReviewEnabledForChallenge:
+        createMockMethod<ReviewService['isInstantReviewEnabledForChallenge']>(),
     };
     reviewService.getTotalAppealCount.mockResolvedValue(1);
     reviewService.getPendingAppealCount.mockResolvedValue(0);
@@ -245,6 +250,7 @@ describe('SchedulerService (review phase deferral)', () => {
     reviewService.getFailedScreeningSubmissionIds.mockResolvedValue(new Set());
     reviewService.getPassedScreeningSubmissionIds.mockResolvedValue(new Set());
     reviewService.getInProgressAiWorkflowRunCount.mockResolvedValue(0);
+    reviewService.isInstantReviewEnabledForChallenge.mockResolvedValue(false);
 
     resourcesService = {
       hasSubmitterResource: jest.fn().mockResolvedValue(true),
@@ -1115,6 +1121,91 @@ describe('SchedulerService (review phase deferral)', () => {
       payload.challengeId,
       payload.phaseId,
       'close',
+    );
+  });
+
+  it('emits AI phase opened event when opening AI Screening with instantReview enabled', async () => {
+    const payload = createPayload({
+      state: 'START',
+      phaseId: 'ai-screening-phase',
+      phaseTypeName: 'AI Screening',
+    });
+
+    const closedPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: false,
+    });
+    const openPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-screening-template',
+      name: 'AI Screening',
+      isOpen: true,
+    });
+
+    challengeApiService.getPhaseDetails
+      .mockResolvedValueOnce(closedPhaseDetails)
+      .mockResolvedValueOnce(openPhaseDetails);
+
+    challengeApiService.getChallengeById.mockResolvedValue({
+      id: payload.challengeId,
+      phases: [closedPhaseDetails],
+      reviewers: [
+        {
+          id: 'reviewer-config-ai',
+          scorecardId: 'scorecard-ai',
+          isMemberReview: false,
+          memberReviewerCount: 0,
+          phaseId: 'ai-screening-template',
+          fixedAmount: null,
+          baseCoefficient: null,
+          incrementalCoefficient: null,
+          type: null,
+          aiWorkflowId: 'workflow-ai-1',
+          shouldOpenOpportunity: false,
+        },
+      ],
+      legacy: {},
+    } as unknown as IChallenge);
+
+    reviewService.isInstantReviewEnabledForChallenge.mockResolvedValue(true);
+
+    const openResponse: Awaited<
+      ReturnType<ChallengeApiService['advancePhase']>
+    > = {
+      success: true,
+      message: 'opened ai screening',
+      updatedPhases: [
+        createPhase({
+          id: payload.phaseId,
+          phaseId: 'ai-screening-template',
+          name: 'AI Screening',
+          isOpen: true,
+          actualStartDate: new Date().toISOString(),
+        }),
+      ],
+    };
+
+    challengeApiService.advancePhase.mockResolvedValueOnce(openResponse);
+
+    await scheduler.advancePhase(payload);
+
+    expect(challengeApiService.advancePhase).toHaveBeenCalledWith(
+      payload.challengeId,
+      payload.phaseId,
+      'open',
+    );
+    expect(kafkaService.produce).toHaveBeenCalledWith(
+      'autopilot.ai.phase.opened',
+      expect.objectContaining({
+        topic: 'autopilot.ai.phase.opened',
+        payload: expect.objectContaining({
+          challengeId: payload.challengeId,
+          phaseId: payload.phaseId,
+          state: 'START',
+        }),
+      }),
     );
   });
 

--- a/src/autopilot/services/scheduler.service.spec.ts
+++ b/src/autopilot/services/scheduler.service.spec.ts
@@ -1209,6 +1209,94 @@ describe('SchedulerService (review phase deferral)', () => {
     );
   });
 
+  it('emits AI phase opened event when opening AI Review with instantReview disabled', async () => {
+    const payload = createPayload({
+      state: 'START',
+      phaseId: 'ai-review-phase',
+      phaseTypeName: 'AI Review',
+    });
+
+    const closedPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-review-template',
+      name: 'AI Review',
+      isOpen: false,
+    });
+    const openPhaseDetails = createPhase({
+      id: payload.phaseId,
+      phaseId: 'ai-review-template',
+      name: 'AI Review',
+      isOpen: true,
+    });
+
+    challengeApiService.getPhaseDetails
+      .mockResolvedValueOnce(closedPhaseDetails)
+      .mockResolvedValueOnce(openPhaseDetails);
+
+    challengeApiService.getChallengeById.mockResolvedValue({
+      id: payload.challengeId,
+      phases: [closedPhaseDetails],
+      reviewers: [
+        {
+          id: 'reviewer-config-ai',
+          scorecardId: 'scorecard-ai',
+          isMemberReview: false,
+          memberReviewerCount: 0,
+          phaseId: 'ai-review-template',
+          fixedAmount: null,
+          baseCoefficient: null,
+          incrementalCoefficient: null,
+          type: null,
+          aiWorkflowId: 'workflow-ai-1',
+          shouldOpenOpportunity: false,
+        },
+      ],
+      legacy: {},
+    } as unknown as IChallenge);
+
+    reviewService.isInstantReviewEnabledForChallenge.mockResolvedValue(false);
+
+    const openResponse: Awaited<
+      ReturnType<ChallengeApiService['advancePhase']>
+    > = {
+      success: true,
+      message: 'opened ai review',
+      updatedPhases: [
+        createPhase({
+          id: payload.phaseId,
+          phaseId: 'ai-review-template',
+          name: 'AI Review',
+          isOpen: true,
+          actualStartDate: new Date().toISOString(),
+        }),
+      ],
+    };
+
+    challengeApiService.advancePhase.mockResolvedValueOnce(openResponse);
+
+    await scheduler.advancePhase(payload);
+
+    expect(reviewService.isInstantReviewEnabledForChallenge).toHaveBeenCalledWith(
+      payload.challengeId,
+    );
+    expect(challengeApiService.advancePhase).toHaveBeenCalledWith(
+      payload.challengeId,
+      payload.phaseId,
+      'open',
+    );
+    expect(kafkaService.produce).toHaveBeenCalledWith(
+      'autopilot.ai.phase.opened',
+      expect.objectContaining({
+        topic: 'autopilot.ai.phase.opened',
+        payload: expect.objectContaining({
+          challengeId: payload.challengeId,
+          phaseId: payload.phaseId,
+          state: 'START',
+        }),
+      }),
+    );
+  });
+
   it('continues opening AI Screening phase when workflow check fails', async () => {
     const payload = createPayload({
       state: 'START',

--- a/src/autopilot/services/scheduler.service.spec.ts
+++ b/src/autopilot/services/scheduler.service.spec.ts
@@ -1124,7 +1124,7 @@ describe('SchedulerService (review phase deferral)', () => {
     );
   });
 
-  it('emits AI phase opened event when opening AI Screening with instantReview enabled', async () => {
+  it('emits AI phase opened event when opening AI Screening with instantReview disabled', async () => {
     const payload = createPayload({
       state: 'START',
       phaseId: 'ai-screening-phase',
@@ -1169,7 +1169,7 @@ describe('SchedulerService (review phase deferral)', () => {
       legacy: {},
     } as unknown as IChallenge);
 
-    reviewService.isInstantReviewEnabledForChallenge.mockResolvedValue(true);
+    reviewService.isInstantReviewEnabledForChallenge.mockResolvedValue(false);
 
     const openResponse: Awaited<
       ReturnType<ChallengeApiService['advancePhase']>

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -1109,10 +1109,11 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
 
       if (operation === 'open' && isAiScreeningPhase) {
         try {
-          shouldEmitAiPhaseOpenedEvent =
+          const instantReviewEnabled =
             await this.reviewService.isInstantReviewEnabledForChallenge(
               data.challengeId,
             );
+          shouldEmitAiPhaseOpenedEvent = !instantReviewEnabled;
         } catch (error) {
           const err = error as Error;
           this.logger.error(
@@ -1124,10 +1125,11 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
 
       if (operation === 'open' && isAiReviewPhase) {
         try {
-          shouldEmitAiPhaseOpenedEvent =
+          const instantReviewEnabled =
             await this.reviewService.isInstantReviewEnabledForChallenge(
               data.challengeId,
             );
+          shouldEmitAiPhaseOpenedEvent = !instantReviewEnabled;
         } catch (error) {
           const err = error as Error;
           this.logger.error(

--- a/src/autopilot/services/scheduler.service.ts
+++ b/src/autopilot/services/scheduler.service.ts
@@ -476,6 +476,38 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  private async emitAiPhaseOpenedEvent(
+    data: PhaseTransitionPayload,
+  ): Promise<void> {
+    const payload: PhaseTransitionPayload = {
+      ...data,
+      state: 'START',
+      operator: data.operator ?? AutopilotOperator.SYSTEM_SCHEDULER,
+      date: new Date().toISOString(),
+    };
+
+    const message: PhaseTransitionMessage = {
+      topic: KAFKA_TOPICS.AI_PHASE_OPENED,
+      originator: 'autopilot-scheduler',
+      timestamp: new Date().toISOString(),
+      mimeType: 'application/json',
+      payload,
+    };
+
+    try {
+      await this.kafkaService.produce(KAFKA_TOPICS.AI_PHASE_OPENED, message);
+      this.logger.log(
+        `[AI PHASE OPENED] Emitted AI phase opened event for challenge ${data.challengeId}, phase ${data.phaseId}`,
+      );
+    } catch (error: unknown) {
+      const err = error as Error;
+      this.logger.error(
+        `[AI PHASE OPENED] Failed to emit AI phase opened event for challenge ${data.challengeId}, phase ${data.phaseId}: ${err.message}`,
+        err.stack,
+      );
+    }
+  }
+
   public async advancePhase(data: PhaseTransitionPayload): Promise<void> {
     try {
       this.logger.log(
@@ -1011,6 +1043,8 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
       }
 
       // Safety check: do not open Appeals if predecessor review has pending reviews
+      let shouldEmitAiPhaseOpenedEvent = false;
+
       if (operation === 'open' && isAppealsPhase) {
         try {
           const challenge = await this.challengeApiService.getChallengeById(
@@ -1073,6 +1107,36 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
         `Phase ${data.phaseId} is currently ${phaseDetails.isOpen ? 'open' : 'closed'}, will ${operation} it`,
       );
 
+      if (operation === 'open' && isAiScreeningPhase) {
+        try {
+          shouldEmitAiPhaseOpenedEvent =
+            await this.reviewService.isInstantReviewEnabledForChallenge(
+              data.challengeId,
+            );
+        } catch (error) {
+          const err = error as Error;
+          this.logger.error(
+            `[AI SCREENING] Unable to determine instantReview readiness for challenge ${data.challengeId}, phase ${data.phaseId}: ${err.message}`,
+            err.stack,
+          );
+        }
+      }
+
+      if (operation === 'open' && isAiReviewPhase) {
+        try {
+          shouldEmitAiPhaseOpenedEvent =
+            await this.reviewService.isInstantReviewEnabledForChallenge(
+              data.challengeId,
+            );
+        } catch (error) {
+          const err = error as Error;
+          this.logger.error(
+            `[AI REVIEW] Unable to determine instantReview readiness for challenge ${data.challengeId}, phase ${data.phaseId}: ${err.message}`,
+            err.stack,
+          );
+        }
+      }
+
       const result = await this.challengeApiService.advancePhase(
         data.challengeId,
         data.phaseId,
@@ -1083,6 +1147,10 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
         this.logger.log(
           `Successfully advanced phase ${data.phaseId} for challenge ${data.challengeId}: ${result.message}`,
         );
+
+        if (operation === 'open' && shouldEmitAiPhaseOpenedEvent) {
+          await this.emitAiPhaseOpenedEvent(data);
+        }
 
         try {
           await this.phaseChangeNotificationService.sendPhaseChangeNotification(
@@ -1297,7 +1365,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
           }
         }
 
-        if (operation === 'open' && isAiScreeningPhase) {
+        if (operation === 'open' && isAiScreeningPhase && !shouldEmitAiPhaseOpenedEvent) {
           try {
             const challenge = await this.challengeApiService.getChallengeById(
               data.challengeId,

--- a/src/kafka/constants/topics.ts
+++ b/src/kafka/constants/topics.ts
@@ -10,6 +10,7 @@ export const KAFKA_TOPICS = {
   REVIEW_COMPLETED: 'review.action.completed',
   REVIEW_APPEAL_RESPONDED: 'review.action.appeal.responded',
   AI_WORKFLOW_COMPLETED: 'aiworkflow.action.completed',
+  AI_PHASE_OPENED: 'autopilot.ai.phase.opened',
   FIRST2FINISH_SUBMISSION_RECEIVED: 'first2finish.submission.received',
   TOPGEAR_SUBMISSION_RECEIVED: 'topgear.submission.received',
 } as const;

--- a/src/kafka/consumers/autopilot.consumer.ts
+++ b/src/kafka/consumers/autopilot.consumer.ts
@@ -75,6 +75,10 @@ export class AutopilotConsumer {
         this.autopilotService.handleAiWorkflowCompleted.bind(
           this.autopilotService,
         ) as (message: AiWorkflowCompletedPayload) => Promise<void>,
+      [KAFKA_TOPICS.AI_PHASE_OPENED]:
+        this.autopilotService.handleAiPhaseOpened.bind(
+          this.autopilotService,
+        ) as (message: PhaseTransitionPayload) => Promise<void>,
       [KAFKA_TOPICS.FIRST2FINISH_SUBMISSION_RECEIVED]:
         this.autopilotService.handleFirst2FinishSubmission.bind(
           this.autopilotService,
@@ -146,6 +150,11 @@ export class AutopilotConsumer {
             case KAFKA_TOPICS.AI_WORKFLOW_COMPLETED:
               await this.autopilotService.handleAiWorkflowCompleted(
                 payload as AiWorkflowCompletedPayload,
+              );
+              break;
+            case KAFKA_TOPICS.AI_PHASE_OPENED:
+              await this.autopilotService.handleAiPhaseOpened(
+                payload as PhaseTransitionPayload,
               );
               break;
             case KAFKA_TOPICS.FIRST2FINISH_SUBMISSION_RECEIVED:

--- a/src/kafka/types/topic-payload-map.type.ts
+++ b/src/kafka/types/topic-payload-map.type.ts
@@ -24,6 +24,7 @@ export type TopicPayloadMap = {
   [KAFKA_TOPICS.REVIEW_COMPLETED]: ReviewCompletedPayload;
   [KAFKA_TOPICS.REVIEW_APPEAL_RESPONDED]: AppealRespondedPayload;
   [KAFKA_TOPICS.AI_WORKFLOW_COMPLETED]: AiWorkflowCompletedPayload;
+  [KAFKA_TOPICS.AI_PHASE_OPENED]: PhaseTransitionPayload;
   [KAFKA_TOPICS.FIRST2FINISH_SUBMISSION_RECEIVED]: First2FinishSubmissionPayload;
   [KAFKA_TOPICS.TOPGEAR_SUBMISSION_RECEIVED]: TopgearSubmissionPayload;
 };

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -3525,6 +3525,47 @@ export class ReviewService {
     }
   }
 
+  async isInstantReviewEnabledForChallenge(
+    challengeId: string,
+  ): Promise<boolean> {
+    if (!challengeId) {
+      return false;
+    }
+
+    const query = Prisma.sql`
+      SELECT c."instantReview" AS "instantReview"
+      FROM ${ReviewService.AI_REVIEW_CONFIG_TABLE} c
+      WHERE c."challengeId" = ${challengeId}
+      ORDER BY c."version" DESC
+      LIMIT 1
+    `;
+
+    try {
+      const rows = await this.prisma.$queryRaw<
+        Array<{ instantReview: boolean | null }>
+      >(query);
+      const instantReview = rows?.[0]?.instantReview === true;
+
+      void this.dbLogger.logAction('review.isInstantReviewEnabledForChallenge', {
+        challengeId,
+        status: 'SUCCESS',
+        source: ReviewService.name,
+        details: { instantReview },
+      });
+
+      return instantReview;
+    } catch (error) {
+      const err = error as Error;
+      void this.dbLogger.logAction('review.isInstantReviewEnabledForChallenge', {
+        challengeId,
+        status: 'ERROR',
+        source: ReviewService.name,
+        details: { error: err.message },
+      });
+      return false;
+    }
+  }
+
   async getTotalAppealCount(challengeId: string): Promise<number> {
     const query = Prisma.sql`
       SELECT COUNT(*)::int AS count


### PR DESCRIPTION
This pull request introduces improved handling for AI Screening and AI Review phases within the autopilot phase scheduling system, especially around the opening of these phases and the interaction with the "instantReview" feature. It ensures that when instantReview is disabled, an explicit event is emitted and handled for AI phase openings, and the phase opening logic is coordinated between the scheduler and autopilot services. The changes also include enhanced test coverage for these scenarios.

**AI Phase Opening and Event Emission:**

* Added logic in `SchedulerService` to emit an `autopilot.ai.phase.opened` Kafka event when opening AI Screening or AI Review phases if instantReview is disabled, and a corresponding handler in `AutopilotService` to log and ignore these events (they will be handled by the reviews-api). 

**Phase Opening Logic Enhancements:**

* Updated `PhaseScheduleManager` to open AI phases using the scheduler, fetch updated phase details, clear polling, and handle instantReview readiness, ensuring correct scheduling and logging throughout.

**Test Improvements:**

* Added and expanded tests in `phase-schedule-manager.service.spec.ts` and `scheduler.service.spec.ts` to cover AI phase opening, instantReview logic, and event emission, including new mocks for methods and services.

**Constants and Utility Additions:**

* Added `AI_PHASE_OPENED` to Kafka topics and utility methods to identify AI Review phases by name.

**Refinements and Safety Checks:**

* Improved safety checks and logging for error handling and phase state validation throughout the scheduler and phase manager logic. 

These changes collectively ensure robust and observable handling of AI phase transitions, especially when instantReview is not enabled, and provide a foundation for future workflow enhancements.