### PR TITLE
PM-5709: Prevent screening before virus scan passes

### DIFF
--- a/src/review/review.service.spec.ts
+++ b/src/review/review.service.spec.ts
@@ -144,7 +144,7 @@ describe('ReviewService', () => {
   });
 
   describe('getActiveContestSubmissions', () => {
-    it('keeps shared active-submission queries limited to active rows', async () => {
+    it('keeps shared queries limited to active, virus-scan-eligible submissions', async () => {
       prismaMock.$queryRaw.mockResolvedValueOnce([
         { id: 'submission-1', memberId: 'member-1', isLatest: false },
         { id: 'submission-2', memberId: 'member-1', isLatest: true },
@@ -169,6 +169,11 @@ describe('ReviewService', () => {
       expect(sqlText).toContain('COALESCE(s."memberId", s."id")');
       expect(sqlText).toContain('s."status" = \'ACTIVE\'');
       expect(sqlText).not.toContain('s."status" = \'AI_FAILED_REVIEW\'');
+      expect(sqlText).toContain('WHERE ranked."isFileSubmission" = FALSE');
+      expect(sqlText).toContain('OR ranked."virusScan" = TRUE');
+      expect(sqlText.indexOf('ROW_NUMBER() OVER')).toBeLessThan(
+        sqlText.indexOf('WHERE ranked."isFileSubmission" = FALSE'),
+      );
 
       expect(dbLoggerMock.logAction).toHaveBeenCalledWith(
         'review.getActiveContestSubmissions',

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -672,26 +672,36 @@ export class ReviewService {
 
     const query = Prisma.sql`
       SELECT
-        s."id",
-        s."memberId",
-        CASE
-          WHEN ROW_NUMBER() OVER (
-            PARTITION BY COALESCE(s."memberId", s."id")
-            ORDER BY
-              s."submittedDate" DESC NULLS LAST,
-              s."createdAt" DESC NULLS LAST,
-              s."updatedAt" DESC NULLS LAST,
-              s."id" DESC
-          ) = 1 THEN TRUE
-          ELSE FALSE
-        END AS "isLatest"
-      FROM ${ReviewService.SUBMISSION_TABLE} s
-      WHERE s."challengeId" = ${challengeId}
-        ${statusFilter}
-        AND (
-          s."type" IS NULL
-          OR UPPER((s."type")::text) = 'CONTEST_SUBMISSION'
-        )
+        ranked."id",
+        ranked."memberId",
+        ranked."isLatest"
+      FROM (
+        SELECT
+          s."id",
+          s."memberId",
+          s."isFileSubmission",
+          s."virusScan",
+          CASE
+            WHEN ROW_NUMBER() OVER (
+              PARTITION BY COALESCE(s."memberId", s."id")
+              ORDER BY
+                s."submittedDate" DESC NULLS LAST,
+                s."createdAt" DESC NULLS LAST,
+                s."updatedAt" DESC NULLS LAST,
+                s."id" DESC
+            ) = 1 THEN TRUE
+            ELSE FALSE
+          END AS "isLatest"
+        FROM ${ReviewService.SUBMISSION_TABLE} s
+        WHERE s."challengeId" = ${challengeId}
+          ${statusFilter}
+          AND (
+            s."type" IS NULL
+            OR UPPER((s."type")::text) = 'CONTEST_SUBMISSION'
+          )
+      ) ranked
+      WHERE ranked."isFileSubmission" = FALSE
+        OR ranked."virusScan" = TRUE
     `;
 
     try {


### PR DESCRIPTION
## What was broken

Autopilot created Screening review assignments for active file submissions before antivirus scanning passed. Reviewers could therefore complete screening for submissions whose files were correctly blocked from download.

## Root cause

The phase-open contest-submission query filtered candidates by challenge, status, and submission type, but did not enforce antivirus eligibility. The scan-complete review creation path already required a passed scan, leaving the bulk phase-open path inconsistent.

## What was changed

The contest-submission query now calculates latest-submission ranking before filtering candidates to URL-only submissions or file submissions with a passed virus scan. This prevents failed and pending file scans from receiving reviews without promoting an older upload when the newest upload is ineligible.

## Any added/updated tests

Updated `ReviewService` unit coverage to verify the antivirus predicate and assert that it is applied after latest-submission ranking.

Validation completed:

- `pnpm test --runInBand src/review/review.service.spec.ts` — 35 tests passed
- `pnpm test --runInBand` — 201 tests passed
- `pnpm lint` — passed
- `pnpm build` — passed
